### PR TITLE
Decouple enemy encounter size from player party growth

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
+++ b/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
@@ -49,7 +49,7 @@ These upgrades persist through wipes, but unspent Gold is still lost on party de
 
 ### Enemy Scaling
 
-Dungeon generation spawns between `1` and the current active party size in enemies per floor, capped at `5` total enemies. The floor still acts as the pacing gate, with encounter size increasing gradually as floors rise.
+Dungeon generation scales enemy counts independently from player party size. On standard floors, encounters spawn `ceil(Floor / 5)` enemies, capped at `5` total enemies, so the dungeon still ramps upward in discrete bands as the player climbs. Unlocking or recruiting additional party members does not increase enemy count by itself.
 Instead of tracking separate enemy classes, standard monsters scale their internal attributes directly based on the floor number (represented as `level` internally during generation):
 
 * `VIT: 5 + (Level * 2)`
@@ -57,7 +57,7 @@ Instead of tracking separate enemy classes, standard monsters scale their intern
 * `INT & WIS: 2 + Level`
 
 **Boss Encounters:**
-Every 10th floor is flagged as a Boss floor. The generated enemy on this floor has their final calculated VIT multiplied by `3` and their STR multiplied by `2`, forming massive spikes in required damage and durability to overcome.
+Every 10th floor is flagged as a Boss floor. Boss floors spawn exactly **one** enemy regardless of player party size, and that generated boss has their final calculated VIT multiplied by `3` and their STR multiplied by `2`, forming a focused spike in required damage and durability to overcome.
 
 ### Party Wipe & Hard Reset
 

--- a/src/game/engine/simulation.test.ts
+++ b/src/game/engine/simulation.test.ts
@@ -3,9 +3,26 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createEnemy, createHero } from "../entity";
 
-import { createInitialGameState, simulateTick } from "./simulation";
+import { createEncounter, createInitialGameState, getEncounterSize, isBossFloor, simulateTick } from "./simulation";
 
 describe("simulation engine", () => {
+    it("scales standard encounters by floor instead of player party size", () => {
+        expect(getEncounterSize(1)).toBe(1);
+        expect(getEncounterSize(6)).toBe(2);
+        expect(getEncounterSize(14)).toBe(3);
+        expect(getEncounterSize(24)).toBe(5);
+    });
+
+    it("keeps boss floors to a single boss encounter", () => {
+        expect(isBossFloor(20)).toBe(true);
+        expect(getEncounterSize(20)).toBe(1);
+
+        const encounter = createEncounter(20);
+
+        expect(encounter).toHaveLength(1);
+        expect(encounter[0]?.name.startsWith("Boss:")).toBe(true);
+    });
+
     it("applies light resistance to cleric smite damage", () => {
         const cleric = createHero("hero_1", "Ayla", "Cleric");
         cleric.actionProgress = 99;

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -19,13 +19,19 @@ export interface SimulationResult {
     outcome: SimulationOutcome;
 }
 
-export const getEncounterSize = (floor: number, partySize: number) => {
+export const isBossFloor = (floor: number) => floor % 10 === 0;
+
+export const getEncounterSize = (floor: number) => {
+    if (isBossFloor(floor)) {
+        return 1;
+    }
+
     const floorCap = Math.max(1, Math.min(MAX_PARTY_SIZE, Math.ceil(floor / 5)));
-    return Math.max(1, Math.min(partySize, floorCap));
+    return floorCap;
 };
 
-export const createEncounter = (floor: number, partySize: number) => {
-    return Array.from({ length: getEncounterSize(floor, partySize) }, (_, index) => createEnemy(floor, `enemy_${floor}_${index}`));
+export const createEncounter = (floor: number) => {
+    return Array.from({ length: getEncounterSize(floor) }, (_, index) => createEnemy(floor, `enemy_${floor}_${index}`));
 };
 
 export const cloneEntity = (entity: Entity): Entity => ({
@@ -70,19 +76,19 @@ export const createInitialGameState = (overrides?: Partial<GameState>): GameStat
 
 export const getInitializedPartyState = (state: GameState, party: Entity[]): Partial<GameState> => ({
     party: recalculateParty(party, state.metaUpgrades),
-    enemies: createEncounter(1, party.length),
+    enemies: createEncounter(1),
     combatLog: [`${party[0]?.name ?? "The party"} leads the party into the dungeon...`],
     activeSection: "dungeon",
 });
 
 export const getFloorTransitionState = (state: GameState, floor: number): Partial<GameState> => ({
     floor,
-    enemies: createEncounter(floor, state.party.length),
+    enemies: createEncounter(floor),
     combatLog: prependCombatMessages(state.combatLog, `Moved to floor ${floor}...`),
 });
 
 export const getFloorReplayState = (state: GameState): Partial<GameState> => ({
-    enemies: createEncounter(state.floor, state.party.length),
+    enemies: createEncounter(state.floor),
     combatLog: prependCombatMessages(state.combatLog, `Repeating floor ${state.floor}...`),
 });
 
@@ -98,7 +104,7 @@ export const getPartyWipeState = (state: GameState): Partial<GameState> => {
         floor: 1,
         gold: new Decimal(0),
         party: healedParty,
-        enemies: createEncounter(1, healedParty.length),
+        enemies: createEncounter(1),
         combatLog: prependCombatMessages(state.combatLog, "The party was wiped out! Resetting to Floor 1..."),
     };
 };

--- a/src/game/store/gameStore.test.ts
+++ b/src/game/store/gameStore.test.ts
@@ -139,6 +139,29 @@ describe("createGameStore", () => {
         expect(state.party.every((hero) => hero.currentHp.eq(hero.maxHp))).toBe(true);
     });
 
+    it("does not scale boss-floor encounter size with additional recruited heroes", () => {
+        const party = createStarterParty("Ayla", "Warrior");
+        party.push(createRecruitHero("Cleric", party));
+        party.push(createRecruitHero("Archer", party));
+        party.push(createRecruitHero("Warrior", party));
+
+        const store = createGameStore({
+            floor: 19,
+            party,
+            enemies: [createEnemy(19, "enemy_19")],
+            combatLog: [],
+        });
+
+        store.getState().nextFloor();
+
+        const state = store.getState();
+
+        expect(state.floor).toBe(20);
+        expect(state.party).toHaveLength(4);
+        expect(state.enemies).toHaveLength(1);
+        expect(state.enemies[0]?.name.startsWith("Boss:")).toBe(true);
+    });
+
     it("buys training upgrades and recalculates party damage", () => {
         const store = createGameStore({
             gold: new Decimal(100),


### PR DESCRIPTION
## Summary
- decouple encounter size from active player party length
- keep boss floors as single-boss encounters regardless of roster size
- add regression tests and update scaling documentation

## Verification
- npm test
- npm run build
- npm run lint

Closes #15
