### PR TITLE
Fix deployment-blocking test regressions

### DIFF
--- a/src/App.integration.test.tsx
+++ b/src/App.integration.test.tsx
@@ -48,7 +48,7 @@ describe("App integration", () => {
 
         await user.click(screen.getByRole("button", { name: /upgrade shop/i }));
 
-        expect(screen.getByText(/sanctum upgrades/i)).toBeInTheDocument();
+        expect(screen.getByRole("tab", { name: /sanctum upgrades/i })).toBeInTheDocument();
         expect(screen.getByText(/party expansion/i)).toBeInTheDocument();
         expect(screen.getByRole("button", { name: /unlock slot \(60 gold\)/i })).toBeInTheDocument();
         expect(screen.getByRole("button", { name: /recruit warrior/i })).toBeDisabled();
@@ -75,7 +75,7 @@ describe("App integration", () => {
         await user.upload(screen.getByLabelText(/import save file/i), saveFile);
 
         expect(screen.getByText("77 Gold")).toBeInTheDocument();
-        expect(screen.getByText(/sanctum upgrades/i)).toBeInTheDocument();
+        expect(screen.getByRole("tab", { name: /sanctum upgrades/i })).toBeInTheDocument();
         expect(screen.getByText(/party expansion/i)).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: /start journey/i })).not.toBeInTheDocument();
     });

--- a/src/components/EntityRoster.test.tsx
+++ b/src/components/EntityRoster.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import type { Entity } from "@/game/entity";
+import { GameProvider } from "@/game/gameState";
 
 import { EntityRoster } from "./EntityRoster";
 
@@ -33,7 +34,11 @@ const heroEntity: Entity = {
 
 describe("EntityRoster", () => {
     it("shows a current cast banner near the entity portrait", () => {
-        render(<EntityRoster title="Party" entities={[heroEntity]} />);
+        render(
+            <GameProvider initialState={{ party: [heroEntity] }}>
+                <EntityRoster title="Party" entities={[heroEntity]} />
+            </GameProvider>,
+        );
 
         expect(screen.getByText(/casting mend/i)).toBeInTheDocument();
     });

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -77,4 +77,4 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   )
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Summary
- fix App integration tests that were using ambiguous `getByText(/sanctum upgrades/i)` queries against the current shop UI
- wrap `EntityRoster` tests in `GameProvider` so the component has the required store context
- remove an unused non-component export from `tabs.tsx` so lint stays green during verification

## Verification
- npm test -- src/App.integration.test.tsx src/components/EntityRoster.test.tsx
- npm run lint
- npm test
- npm run build

Closes #19
