### PR TITLE
feat: Insight XP Prestige Upgrade

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/006-hero-retirement-and-prestige.md
+++ b/docs/ARCHITECTURE/gamedecisions/006-hero-retirement-and-prestige.md
@@ -27,6 +27,10 @@ The Altar provides upgrades that alter fundamental game mechanics, not just flat
    - *Effect:* Increases the global game tick speed multiplier.
    - *Mechanic:* Every level provides a +10% `hasteBonus` to the overall `actionProgress` accumulation rate, making heroes attack and cast spells faster across the board.
 
+4. **Insight (XP Multiplier)**
+   - *Effect:* Increases experience gained from all defeated enemies.
+   - *Mechanic:* Each level grants a flat +20% multiplier to the base experience calculation (`baseExp * (1 + level * 0.2)`). This acts as a catch-up mechanic so players can level recruited replacements faster after a retirement.
+
 ## Consequences
 - **Positive:** Introduces a compelling choice (sacrificing a high-level hero) for long-term power. It provides a prestige system without the friction of a total progress wipe.
 - **Negative:** The player must re-grind a new hero from Level 1 after a retirement, requiring careful UI communication (via a confirmation dialog) so players don't accidentally ruin their active party composition.

--- a/src/components/PrestigeUpgradesPanel.tsx
+++ b/src/components/PrestigeUpgradesPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CircleDollarSign, FastForward, HeartPulse } from "lucide-react";
+import { CircleDollarSign, FastForward, HeartPulse, Brain } from "lucide-react";
 
 import { useGame } from "../game/store/gameStore";
 import { formatNumber } from "../utils/format";
@@ -14,10 +14,12 @@ export const PrestigeUpgradesPanel: React.FC = () => {
     const currentCostReducerLevel = prestigeUpgrades.costReducer;
     const currentHpLevel = prestigeUpgrades.hpMultiplier;
     const currentGameSpeedLevel = prestigeUpgrades.gameSpeed;
+    const currentXpLevel = prestigeUpgrades.xpMultiplier;
 
     const costReducerCost = actions.getPrestigeUpgradeCost("costReducer");
     const hpMultiplierCost = actions.getPrestigeUpgradeCost("hpMultiplier");
     const gameSpeedCost = actions.getPrestigeUpgradeCost("gameSpeed");
+    const xpMultiplierCost = actions.getPrestigeUpgradeCost("xpMultiplier");
 
     return (
         <Card className="w-full max-w-150 bg-slate-900/80 backdrop-blur-md border-fuchsia-700/50 shadow-xl mt-4 shrink-0 [box-shadow:0_0_15px_rgba(192,38,211,0.1)]">
@@ -76,7 +78,7 @@ export const PrestigeUpgradesPanel: React.FC = () => {
                     </Button>
                 </div>
 
-                <div className="rounded-xl border border-fuchsia-700/30 bg-slate-900/70 p-4 flex flex-col gap-3 md:col-span-2">
+                <div className="rounded-xl border border-fuchsia-700/30 bg-slate-900/70 p-4 flex flex-col gap-3">
                     <div className="flex items-start justify-between gap-4">
                         <div>
                             <div className="flex items-center gap-2 text-fuchsia-200 font-bold">
@@ -94,6 +96,27 @@ export const PrestigeUpgradesPanel: React.FC = () => {
                         className="w-full border-fuchsia-800 text-fuchsia-300 hover:bg-fuchsia-950 uppercase font-black tracking-wider text-xs"
                     >
                         Imbue ({formatNumber(gameSpeedCost)} Souls)
+                    </Button>
+                </div>
+
+                <div className="rounded-xl border border-fuchsia-700/30 bg-slate-900/70 p-4 flex flex-col gap-3">
+                    <div className="flex items-start justify-between gap-4">
+                        <div>
+                            <div className="flex items-center gap-2 text-fuchsia-200 font-bold">
+                                <Brain size={16} className="text-blue-400" />
+                                Insight
+                            </div>
+                            <p className="text-xs text-slate-400 mt-1">Increases experience gained from enemies by 20% per level.</p>
+                        </div>
+                        <span className="text-xs font-black uppercase tracking-wider text-blue-400">Lv {currentXpLevel}</span>
+                    </div>
+                    <Button 
+                        disabled={heroSouls.lt(xpMultiplierCost)}
+                        onClick={() => actions.buyPrestigeUpgrade("xpMultiplier")}
+                        variant="outline" 
+                        className="w-full border-fuchsia-800 text-fuchsia-300 hover:bg-fuchsia-950 uppercase font-black tracking-wider text-xs"
+                    >
+                        Imbue ({formatNumber(xpMultiplierCost)} Souls)
                     </Button>
                 </div>
             </CardContent>

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -77,6 +77,7 @@ export const createInitialGameState = (overrides?: Partial<GameState>): GameStat
         costReducer: overrides?.prestigeUpgrades?.costReducer ?? 0,
         hpMultiplier: overrides?.prestigeUpgrades?.hpMultiplier ?? 0,
         gameSpeed: overrides?.prestigeUpgrades?.gameSpeed ?? 0,
+        xpMultiplier: overrides?.prestigeUpgrades?.xpMultiplier ?? 0,
     },
 });
 
@@ -272,7 +273,9 @@ export const simulateTick = (state: GameState): SimulationResult => {
 
         logMessages.push(`${target.name} was defeated!`);
 
-        const experienceReward = new Decimal(draft.floor).times(10).plus(target.attributes.vit);
+        const baseExp = new Decimal(draft.floor).times(10).plus(target.attributes.vit);
+        const xpBonus = 1 + (draft.prestigeUpgrades.xpMultiplier * 0.2); // +20% base EXP per level
+        const experienceReward = baseExp.times(xpBonus).floor();
         const goldReward = new Decimal(draft.floor).times(2).plus(5);
         draft.gold = draft.gold.plus(goldReward);
 

--- a/src/game/store/persistence.ts
+++ b/src/game/store/persistence.ts
@@ -75,6 +75,7 @@ const toPartialGameState = (value: unknown): Partial<GameState> => {
             costReducer: typeof value.prestigeUpgrades.costReducer === "number" ? value.prestigeUpgrades.costReducer : 0,
             hpMultiplier: typeof value.prestigeUpgrades.hpMultiplier === "number" ? value.prestigeUpgrades.hpMultiplier : 0,
             gameSpeed: typeof value.prestigeUpgrades.gameSpeed === "number" ? value.prestigeUpgrades.gameSpeed : 0,
+            xpMultiplier: typeof value.prestigeUpgrades.xpMultiplier === "number" ? value.prestigeUpgrades.xpMultiplier : 0,
         };
         candidate.prestigeUpgrades = prestigeUpgrades;
     }

--- a/src/game/store/progressionSlice.ts
+++ b/src/game/store/progressionSlice.ts
@@ -8,6 +8,7 @@ export const PRESTIGE_BASE_COSTS: Record<keyof PrestigeUpgrades, number> = {
     costReducer: 10,
     hpMultiplier: 15,
     gameSpeed: 25,
+    xpMultiplier: 10,
 };
 
 export const selectProgressionState = (state: GameState): ProgressionSlice => ({
@@ -154,6 +155,7 @@ export const createProgressionSlice = (
                     costReducer: "Greed (Gold Cost Reducer)",
                     hpMultiplier: "Vitality (HP Multiplier)",
                     gameSpeed: "Haste (Game Speed Booster)",
+                    xpMultiplier: "Insight (XP Multiplier)",
                 };
 
                 const newPrestigeUpgrades = {

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -20,6 +20,7 @@ export interface PrestigeUpgrades {
     costReducer: number;
     hpMultiplier: number;
     gameSpeed: number;
+    xpMultiplier: number;
 }
 
 export interface ProgressionSlice {


### PR DESCRIPTION
Resolves #21

Adds the 4th Prestige Upgrade ('Insight') to the Altar of Souls. 
- Grants a flat +20% experience multiplier per level to help newly recruited heroes catch up after a retirement.
- Adds  to the game state.
- Wires the modifier accurately into  combat resolution.
- Updates the PrestigeUpgradesPanel to display the new upgrade.