### PR TITLE
Fix deploy build failure from UpgradesPanel test typing

### DIFF
--- a/src/components/UpgradesPanel.test.tsx
+++ b/src/components/UpgradesPanel.test.tsx
@@ -136,7 +136,7 @@ describe("UpgradesPanel", () => {
             </GameProvider>,
         );
 
-        const battleDrillsCard = screen.getByText("Battle Drills").closest("div.rounded-xl");
+        const battleDrillsCard = screen.getByText("Battle Drills").closest<HTMLElement>("div.rounded-xl");
 
         if (!battleDrillsCard) {
             throw new Error("Expected Battle Drills upgrade card to be rendered.");
@@ -144,7 +144,7 @@ describe("UpgradesPanel", () => {
 
         expect(within(battleDrillsCard).getByRole("button", { name: /upgrade/i })).toHaveTextContent("73.79k");
 
-        const greedCard = screen.getByText("Greed").closest("div.rounded-xl");
+        const greedCard = screen.getByText("Greed").closest<HTMLElement>("div.rounded-xl");
 
         if (!greedCard) {
             throw new Error("Expected Greed prestige card to be rendered.");


### PR DESCRIPTION
## Summary
- fix the `UpgradesPanel` regression test typing so `closest()` returns `HTMLElement` for Testing Library's `within(...)`
- preserve the existing null checks and test behavior
- restore `npm run build` so the GitHub Pages deploy workflow can complete

## Validation
- `npm run build`
- `npm test`

## Links
- Fixes #25
- Failing Actions run: https://github.com/deadronos/idle-dungeon-crawler/actions/runs/22949520272/job/66610343054