### PR TITLE
[codex] fix hero parry against melee enemies

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
+++ b/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
@@ -36,7 +36,7 @@ Currently, action resolution uses a lightweight class-aware ruleset:
    * Warriors spend Rage on `Rage Strike` once they have enough stored resource (50 Rage for a 2× damage attack; warriors gain 10 Rage when hitting and 5 Rage when hit).
    * Archers spend Cunning on `Piercing Shot` once they have enough stored resource (25 Cunning for 1.6× damage and +25% crit chance).
    * Resource regeneration is handled per tick: clerics regain `WIS * 0.5` Mana, archers regain `2` Cunning, and warriors generate Rage only through combat triggers. Warriors start runs with 0 Rage, while clerics and archers begin with full resource pools.
-3. **Action Metadata:** Every damaging action declares a `deliveryType` (`melee`, `ranged`, or `spell`) and a `damageElement` (`physical`, `fire`, `water`, `earth`, `air`, `light`, `shadow`). This keeps future attacks extensible without hand-written resolution logic per skill.
+3. **Action Metadata:** Every damaging action declares a `deliveryType` (`melee`, `ranged`, or `spell`) and a `damageElement` (`physical`, `fire`, `water`, `earth`, `air`, `light`, `shadow`). Standard Monster auto-attacks are intentionally `melee + physical`, while Archer basics remain `ranged + physical` and Cleric `Smite` remains `spell + light`. This keeps future attacks extensible without hand-written resolution logic per skill and avoids silently classifying all enemies as ranged attackers.
 4. **Hit Resolution:**
    * Most physical attacks use a contested hit formula based on the attacker's `Accuracy Rating` and the defender's `Evasion Rating`.
    * Spells use a magic-biased variant that adds the attacker's `INT` and defender's `WIS` before clamping the final hit chance.

--- a/src/game/engine/simulation.test.ts
+++ b/src/game/engine/simulation.test.ts
@@ -110,6 +110,35 @@ describe("simulation engine", () => {
         expect(result.state.combatEvents.some((event) => event.kind === "parry")).toBe(true);
     });
 
+    it("lets heroes parry melee enemy attacks", () => {
+        const warrior = createHero("hero_1", "Brom", "Warrior");
+        warrior.parryRating = 200;
+        warrior.currentHp = warrior.maxHp;
+
+        const enemy = createEnemy(1, "enemy_1");
+        enemy.actionProgress = 99;
+        enemy.critChance = 0;
+        const startingHp = warrior.currentHp;
+
+        vi.spyOn(Math, "random")
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(0.2);
+
+        const result = simulateTick(
+            createInitialGameState({
+                party: [warrior],
+                enemies: [enemy],
+                combatLog: [],
+            }),
+        );
+
+        expect(result.state.party[0].currentHp.eq(startingHp)).toBe(true);
+        expect(result.state.combatLog[0]).toMatch(/parries/i);
+        expect(result.state.combatLog[0]).toMatch(/Brom parries Sewer Rat Lv1's Attack!/);
+        expect(result.state.combatEvents.some((event) => event.kind === "parry" && event.targetId === warrior.id)).toBe(true);
+    });
+
     it("does not let ranged physical attacks be parried", () => {
         const archer = createHero("hero_1", "Vera", "Archer");
         archer.actionProgress = 99;

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -208,10 +208,10 @@ const getDamageAction = (entity: Entity): DamageAction => {
         name: "Attack",
         damage: entity.physicalDamage,
         damageElement: "physical",
-        deliveryType: entity.class === "Archer" || entity.isEnemy ? "ranged" : "melee",
+        deliveryType: entity.class === "Archer" ? "ranged" : "melee",
         critChance: entity.critChance,
         canDodge: true,
-        canParry: !(entity.class === "Archer" || entity.isEnemy),
+        canParry: entity.class !== "Archer",
     };
 
     if (entity.class === "Cleric") {


### PR DESCRIPTION
Closes #56.

This change fixes a combat asymmetry where baseline monsters were implicitly treated as ranged physical attackers. In practice that meant enemy parry already mattered against warrior melee attacks, but hero parry almost never mattered against standard enemies because those enemy attacks bypassed the melee-only parry rules.

The root cause was in the default damage action builder. It used `entity.isEnemy` as part of the condition that selected `ranged` delivery and disabled parry, so every Monster auto-attack inherited ranged behavior even though the intended shared melee-defense model was for standard enemies and melee heroes to interact through the same dodge/parry rules.

The fix makes the default physical auto-attack melee unless the acting unit is explicitly an Archer. Cleric `Smite` still overrides to `spell + light`, and Archer attacks still remain ranged and unparryable unless a future action opts into something different. I also updated the combat decision record so the intended monster default is written down in the architecture docs instead of being left as an implementation accident.

Validation included a new regression test that covers the missing direction: a hero parrying a melee enemy attack. The existing tests already covered enemy parries against hero melee and confirmed that ranged physical attacks still cannot be parried, so the suite now exercises both sides of the symmetry called out in the issue. I also ran the full repo checks (`npm test`, `npm run lint`, `npm run build`) and performed a quick browser sanity check against the local Vite app to confirm the dungeon UI still loads and combat log updates normally.
