### PR TITLE
[codex] retune boss spikes and slot milestones

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
+++ b/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
@@ -36,9 +36,9 @@ Gold can be invested into persistent party-wide upgrades before a wipe occurs. T
 * **Fortification:** Increases all hero armor by `10%` per level.
 * **Party Slot Expansion:** Active party capacity starts at `1` and can be permanently increased to `5` by clearing milestone floors and then purchasing the next slot in the shop.
   * Capacity `2`: clear Floor `3`, then pay `60` Gold
-  * Capacity `3`: clear Floor `10`, then pay `180` Gold
-  * Capacity `4`: clear Floor `20`, then pay `500` Gold
-  * Capacity `5`: clear Floor `35`, then pay `1200` Gold
+  * Capacity `3`: clear Floor `8`, then pay `180` Gold
+  * Capacity `4`: clear Floor `18`, then pay `500` Gold
+  * Capacity `5`: clear Floor `28`, then pay `1200` Gold
 * **Recruitment:** After an empty slot is available, the player can recruit a new active hero in the shop and choose that hero's class. Duplicate classes are allowed. Recruit costs scale with current party size:
   * Party size `1` → recruit cost `30` Gold
   * Party size `2` → recruit cost `90` Gold
@@ -57,7 +57,7 @@ Instead of tracking separate enemy classes, standard monsters scale their intern
 * `INT & WIS: 2 + Level`
 
 **Boss Encounters:**
-Every 10th floor is flagged as a Boss floor. Boss floors spawn exactly **one** enemy regardless of player party size, and that generated boss has their final calculated VIT multiplied by `3` and their STR multiplied by `2`, forming a focused spike in required damage and durability to overcome.
+Every 10th floor is flagged as a Boss floor. Boss floors spawn exactly **one** enemy regardless of player party size, and that generated boss has their calculated VIT multiplied by `2` and their STR multiplied by `1.3`. This keeps bosses meaningfully tougher than adjacent floors without recreating the old solo/duo progression wall at Floor `10` or pushing the same pacing problem forward to the later slot milestones.
 
 ### Party Wipe & Hard Reset
 

--- a/docs/ARCHITECTURE/gamedecisions/005-expandable-party-system.md
+++ b/docs/ARCHITECTURE/gamedecisions/005-expandable-party-system.md
@@ -39,9 +39,9 @@ The slot ladder is:
 | Unlocks Capacity | Milestone Floor Reached | Gold Cost |
 | --- | --- | --- |
 | 2 heroes | Floor 3 | 60 |
-| 3 heroes | Floor 10 | 180 |
-| 4 heroes | Floor 20 | 500 |
-| 5 heroes | Floor 35 | 1200 |
+| 3 heroes | Floor 8 | 180 |
+| 4 heroes | Floor 18 | 500 |
+| 5 heroes | Floor 28 | 1200 |
 
 Recruitment is a separate purchase from capacity. Recruit costs scale with current party size:
 
@@ -100,6 +100,6 @@ The first version of this system should intentionally stay narrow:
 
 * **Easier:** The player gains a clearer sense of long-term growth because party expansion becomes a visible reward path rather than a one-time starting grant.
 * **Easier:** The Upgrade Shop becomes a more meaningful strategic hub because it now governs both stat upgrades and roster growth.
-* **Difficult:** Early-game balance must be re-tuned for solo starts so the first few floors remain survivable and rewarding.
+* **Difficult:** Early-game balance must stay aligned with the slot ladder so new capacity unlocks arrive before the next major boss or encounter-size spike rather than after it.
 * **Difficult:** Encounter generation and roster UI may need to scale beyond the current assumptions that naturally fit a three-hero party.
 * **Difficult:** Tests and state management become more complex because party size is now dynamic and persistent across wipes.

--- a/src/components/UpgradesPanel.test.tsx
+++ b/src/components/UpgradesPanel.test.tsx
@@ -90,7 +90,7 @@ describe("UpgradesPanel", () => {
         expect(screen.getByText(/current recruit cost: 90 gold/i)).toBeInTheDocument();
     });
 
-    it("unlocks the third party slot after floor 10 has been cleared", async () => {
+    it("unlocks the third party slot after floor 8 has been cleared", async () => {
         const user = userEvent.setup();
 
         render(
@@ -99,7 +99,7 @@ describe("UpgradesPanel", () => {
                     gold: new Decimal(1000),
                     party: createStarterParty("Ayla", "Warrior"),
                     partyCapacity: 2,
-                    highestFloorCleared: 11,
+                    highestFloorCleared: 8,
                 }}
             >
                 <UpgradesPanel />

--- a/src/game/entity.test.ts
+++ b/src/game/entity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { BASE_META_UPGRADES, createEnemy, createHero, createRecruitHero, createStarterParty } from "./entity";
+import { BASE_META_UPGRADES, BOSS_STRENGTH_MULTIPLIER, BOSS_VITALITY_MULTIPLIER, createEnemy, createHero, createRecruitHero, createStarterParty } from "./entity";
 
 describe("entity model", () => {
     it("creates a single-hero starter party around the selected leader", () => {
@@ -41,12 +41,13 @@ describe("entity model", () => {
         expect(warrior.parryRating).toBeCloseTo(18.75);
     });
 
-    it("creates tougher boss enemies on every tenth floor", () => {
-        const floorNineEnemy = createEnemy(9, "enemy_9");
+    it("creates tougher boss enemies on every tenth floor with the softened boss multipliers", () => {
         const bossEnemy = createEnemy(10, "enemy_10");
+        const expectedBaseVit = 5 + (10 * 2);
+        const expectedBaseStr = 5 + (10 * 1.5);
 
         expect(bossEnemy.name.startsWith("Boss:")).toBe(true);
-        expect(bossEnemy.maxHp.gt(floorNineEnemy.maxHp)).toBe(true);
-        expect(bossEnemy.physicalDamage.gt(floorNineEnemy.physicalDamage)).toBe(true);
+        expect(bossEnemy.attributes.vit).toBe(expectedBaseVit * BOSS_VITALITY_MULTIPLIER);
+        expect(bossEnemy.attributes.str).toBe(expectedBaseStr * BOSS_STRENGTH_MULTIPLIER);
     });
 });

--- a/src/game/entity.ts
+++ b/src/game/entity.ts
@@ -79,6 +79,8 @@ export const BASE_META_UPGRADES: MetaUpgrades = {
 };
 
 export const HERO_CLASSES: HeroClass[] = ["Warrior", "Cleric", "Archer"];
+export const BOSS_VITALITY_MULTIPLIER = 2;
+export const BOSS_STRENGTH_MULTIPLIER = 1.3;
 
 const HERO_NAME_POOLS: Record<HeroClass, string[]> = {
     Warrior: ["Brom", "Tarin", "Mira", "Hale", "Sable"],
@@ -323,8 +325,8 @@ export const createEnemy = (level: number, id: string): Entity => {
 
     // Boss floor
     if (level % 10 === 0) {
-        enemy.attributes.vit *= 3;
-        enemy.attributes.str *= 2;
+        enemy.attributes.vit *= BOSS_VITALITY_MULTIPLIER;
+        enemy.attributes.str *= BOSS_STRENGTH_MULTIPLIER;
         enemy.name = `Boss: ${enemy.name}`;
     }
 

--- a/src/game/partyProgression.test.ts
+++ b/src/game/partyProgression.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { PARTY_SLOT_UNLOCKS, canUnlockPartySlot, getNextPartySlotUnlock, getPartySlotUnlockCost, getRecruitCost } from "./partyProgression";
+
+describe("party progression", () => {
+    it("keeps the retuned slot ladder ahead of the next major pressure spikes", () => {
+        expect(PARTY_SLOT_UNLOCKS).toEqual([
+            { capacity: 2, milestoneFloor: 3, cost: 60 },
+            { capacity: 3, milestoneFloor: 8, cost: 180 },
+            { capacity: 4, milestoneFloor: 18, cost: 500 },
+            { capacity: 5, milestoneFloor: 28, cost: 1200 },
+        ]);
+    });
+
+    it("only unlocks slots after the new milestone floors are cleared", () => {
+        expect(canUnlockPartySlot(1, 2)).toBe(false);
+        expect(canUnlockPartySlot(1, 3)).toBe(true);
+        expect(canUnlockPartySlot(2, 7)).toBe(false);
+        expect(canUnlockPartySlot(2, 8)).toBe(true);
+        expect(canUnlockPartySlot(3, 17)).toBe(false);
+        expect(canUnlockPartySlot(3, 18)).toBe(true);
+        expect(canUnlockPartySlot(4, 27)).toBe(false);
+        expect(canUnlockPartySlot(4, 28)).toBe(true);
+    });
+
+    it("returns the next slot unlock and costs for the current party size", () => {
+        expect(getNextPartySlotUnlock(1)).toEqual({ capacity: 2, milestoneFloor: 3, cost: 60 });
+        expect(getNextPartySlotUnlock(2)).toEqual({ capacity: 3, milestoneFloor: 8, cost: 180 });
+        expect(getNextPartySlotUnlock(4)).toEqual({ capacity: 5, milestoneFloor: 28, cost: 1200 });
+        expect(getNextPartySlotUnlock(5)).toBeNull();
+
+        expect(getPartySlotUnlockCost(1)?.toString()).toBe("60");
+        expect(getPartySlotUnlockCost(2)?.toString()).toBe("180");
+        expect(getPartySlotUnlockCost(4)?.toString()).toBe("1200");
+        expect(getPartySlotUnlockCost(5)).toBeNull();
+    });
+
+    it("keeps recruit costs tied to current party size", () => {
+        expect(getRecruitCost(1).toString()).toBe("30");
+        expect(getRecruitCost(2).toString()).toBe("90");
+        expect(getRecruitCost(3).toString()).toBe("220");
+        expect(getRecruitCost(4).toString()).toBe("550");
+    });
+});

--- a/src/game/partyProgression.ts
+++ b/src/game/partyProgression.ts
@@ -14,9 +14,9 @@ export const RECRUITABLE_CLASSES: HeroClass[] = ["Warrior", "Cleric", "Archer"];
 
 export const PARTY_SLOT_UNLOCKS: PartySlotUnlock[] = [
     { capacity: 2, milestoneFloor: 3, cost: 60 },
-    { capacity: 3, milestoneFloor: 10, cost: 180 },
-    { capacity: 4, milestoneFloor: 20, cost: 500 },
-    { capacity: 5, milestoneFloor: 35, cost: 1200 },
+    { capacity: 3, milestoneFloor: 8, cost: 180 },
+    { capacity: 4, milestoneFloor: 18, cost: 500 },
+    { capacity: 5, milestoneFloor: 28, cost: 1200 },
 ];
 
 const RECRUIT_COSTS_BY_PARTY_SIZE: Record<number, number> = {

--- a/src/game/store/gameStore.test.ts
+++ b/src/game/store/gameStore.test.ts
@@ -93,11 +93,11 @@ describe("createGameStore", () => {
         expect(state.combatLog[0]).toMatch(/repeating floor 4/i);
     });
 
-    it("unlocks party slots and recruits duplicate classes after milestone clears", () => {
+    it("unlocks party slots and recruits duplicate classes after the retuned milestone clears", () => {
         const store = createGameStore({
             gold: new Decimal(500),
             party: createStarterParty("Ayla", "Warrior"),
-            highestFloorCleared: 10,
+            highestFloorCleared: 8,
         });
 
         store.getState().unlockPartySlot();
@@ -112,6 +112,12 @@ describe("createGameStore", () => {
         expect(state.party).toHaveLength(2);
         expect(state.party.every((hero) => hero.class === "Warrior")).toBe(true);
         expect(state.gold.toString()).toBe("410");
+
+        store.getState().unlockPartySlot();
+
+        state = store.getState();
+        expect(state.partyCapacity).toBe(3);
+        expect(state.gold.toString()).toBe("230");
     });
 
     it("preserves recruited heroes and unlocked slots through a party wipe", () => {


### PR DESCRIPTION
## Summary
This PR addresses issue #57 by retuning the boss spike and party-slot pacing that were creating a solo-to-duo progression wall around floor 10.

The old ladder required players to clear floor 10 before buying the third party slot, while boss floors were still using a very sharp `VIT x3 / STR x2` spike. In practice that meant the party size needed to stabilize floor 10 only arrived after the floor that demanded it. The same pacing problem then repeated later in the ladder, with capacity 4 and 5 arriving after the major pressure spikes they were meant to help absorb.

## Root Cause
The progression model had two systems compounding each other:

- slot milestones were set at floors 10, 20, and 35 instead of slightly ahead of the next pressure spike
- every boss floor used the same large health and damage multipliers regardless of how early the boss appeared in the run

That combination made floor 10 act as a hard gate for solo and duo runs and threatened to move the same wall upward as the party expanded.

## Fix
This PR makes two coordinated balance changes:

- moves the permanent party-slot milestones from `3 / 10 / 20 / 35` to `3 / 8 / 18 / 28`
- softens boss generation from `VIT x3 / STR x2` to `VIT x2 / STR x1.3`

The milestone retune lets the party grow before floors 10, 20, and 30 rather than after them. The boss retune keeps boss floors meaningfully tougher than adjacent encounters without demanding a party size or upgrade level the player cannot realistically have yet.

## Tests and Validation
I updated and added automated coverage for the new progression rules and boss tuning:

- added `src/game/partyProgression.test.ts` to lock the new slot ladder, unlock checks, and cost helpers
- updated store and component tests to assert the new floor-8 third-slot unlock flow
- updated entity tests to assert the new boss multipliers directly
- ran `npm test`, `npm run lint`, and `npm run build`

I also did a browser sanity check against the local preview build and confirmed that after unlocking slot 2, the shop correctly shows `Requires Floor 8 Cleared` for the next slot.

Closes #57.
