### PR TITLE
[codex] Rebalance class scaling and resource pacing for hit-resolution combat

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/002-attributes-and-stats.md
+++ b/docs/ARCHITECTURE/gamedecisions/002-attributes-and-stats.md
@@ -34,17 +34,17 @@ When a unit is created or levels up, their total attributes are summed and used 
 *   **Physical Damage (Melee):** `10 + (STR * 1.5)`
 *   **Ranged Damage (Archers):** `10 + (DEX * 1.5)`
 *   **Magic Damage:** `5 + (INT * 2.0)`
-*   **Accuracy Rating:** `50 + (DEX * 2) + (INT * 1)`
-*   **Evasion Rating:** `35 + (DEX * 1.5) + (WIS * 1)`
-*   **Parry Rating:** `(STR * 1.5) + (DEX * 0.75)`
+*   **Accuracy Rating:** `50 + (DEX * 1.5) + (INT * 1)`
+*   **Evasion Rating:** `35 + (DEX * 1.0) + (WIS * 1)`
+*   **Parry Rating:** `(STR * 1.75) + (DEX * 0.25)`
 
 These additional ratings are intentionally coupled to the same five core attributes instead of introducing a sixth or seventh combat stat. `DEX` now contributes to both offensive precision and defensive footwork, `STR` helps melee defense through parry, and `WIS` helps magical awareness and avoidance pressure.
 
 ### Classes & Secondary Resources
 Classes use secondary resources to cast powerful abilities (future-proofing) or sustain basic actions:
-*   **Warrior (Rage):** Fixed maximum of `100`. Starts at `0`. Generates `10` Rage when hitting an enemy, and `5` Rage when hit by an enemy.
+*   **Warrior (Rage):** Fixed maximum of `100`. Starts at `0`. Generates `8` Rage after resolving an attack action and `5` Rage when taking damage.
 *   **Cleric (Mana):** Maximum is `50 + (INT * 5)`. Starts full. Regenerates passively based on Wisdom (`WIS * 0.5` per action tick).
-*   **Archer (Cunning):** Maximum is `50 + (INT * 5)`. Starts full. Regenerates at a fixed flat rate (`2` per action tick).
+*   **Archer (Cunning):** Maximum is `50 + (INT * 5)`. Starts full. Regenerates at a fixed flat rate (`0.75` per action tick).
 
 ### Hard Caps
 To prevent infinite scaling breaking the game logic:
@@ -57,9 +57,9 @@ To prevent infinite scaling breaking the game logic:
 ### Combat Role Implications
 The new derived ratings reinforce class roles without adding bespoke per-class rules:
 
-* **Warrior:** naturally develops the highest `Parry Rating` thanks to STR-heavy growth and remains the most reliable melee bruiser.
+* **Warrior:** naturally develops the highest `Parry Rating` thanks to STR-heavy growth and retains a sturdier melee identity now that DEX contributes less to avoidance stacking.
 * **Cleric:** gains steadier spell reliability from INT while WIS continues to scale elemental resistance and magical defense.
-* **Archer:** receives the strongest `Accuracy` and `Evasion` growth through DEX, making the class agile rather than parry-oriented.
+* **Archer:** still receives the strongest `Accuracy` and `Evasion` growth through DEX, but the lighter DEX weighting reduces all-in-one stat stacking and keeps the class focused on agility rather than passive durability.
 * **Monsters:** inherit the same formulas, which keeps enemy combat behavior scalable without a separate balance table for hit logic.
 
 ## Consequences

--- a/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
+++ b/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
@@ -22,7 +22,7 @@ If `Autofight` is disabled, the simulation pauses in place: ATB does not fill, a
 `Autoadvance` is a separate control. When enabled, the party moves to the next floor after winning an encounter. When disabled, the party immediately starts a fresh encounter on the same floor, allowing the player to continuously farm a target floor without climbing past it.
 
 * **Base ATB Rate:** `2.0` per tick.
-* **Speed Bonus:** Dexterity provides a speed bonus calculation: `+ (DEX * 0.1)` per tick.
+* **Speed Bonus:** Dexterity provides a speed bonus calculation: `+ (DEX * 0.06)` per tick.
 
 When an entity's `actionProgress` reaches or exceeds `100`, they consume their bar (reset to `0`) and perform an action.
 
@@ -33,26 +33,26 @@ Currently, action resolution uses a lightweight class-aware ruleset:
 1. **Target Selection:** The acting unit selects a random living target from the opposing side.
 2. **Class Skill Check:**
    * Clerics first check for a badly injured ally and, if sufficient Mana is available, cast a heal instead of attacking (Mend costs **35 Mana**).
-   * Warriors spend Rage on `Rage Strike` once they have enough stored resource (50 Rage for a 2× damage attack; warriors gain 10 Rage when hitting and 5 Rage when hit).
-   * Archers spend Cunning on `Piercing Shot` once they have enough stored resource (25 Cunning for 1.6× damage and +25% crit chance).
-   * Resource regeneration is handled per tick: clerics regain `WIS * 0.5` Mana, archers regain `2` Cunning, and warriors generate Rage only through combat triggers. Warriors start runs with 0 Rage, while clerics and archers begin with full resource pools.
+   * Warriors spend Rage on `Rage Strike` once they have enough stored resource (40 Rage for a 2× damage attack; `Rage Strike` cannot be parried; warriors gain 8 Rage after resolving an attack and 5 Rage when hit).
+   * Archers spend Cunning on `Piercing Shot` once they have enough stored resource (35 Cunning for 1.6× damage and +15% crit chance).
+   * Resource regeneration is handled per tick: clerics regain `WIS * 0.5` Mana, archers regain `0.75` Cunning, and warriors generate Rage only through combat triggers. Warriors start runs with 0 Rage, while clerics and archers begin with full resource pools.
 3. **Action Metadata:** Every damaging action declares a `deliveryType` (`melee`, `ranged`, or `spell`) and a `damageElement` (`physical`, `fire`, `water`, `earth`, `air`, `light`, `shadow`). Standard Monster auto-attacks are intentionally `melee + physical`, while Archer basics remain `ranged + physical` and Cleric `Smite` remains `spell + light`. This keeps future attacks extensible without hand-written resolution logic per skill and avoids silently classifying all enemies as ranged attackers.
 4. **Hit Resolution:**
    * Most physical attacks use a contested hit formula based on the attacker's `Accuracy Rating` and the defender's `Evasion Rating`.
-   * Spells use a magic-biased variant that adds the attacker's `INT` and defender's `WIS` before clamping the final hit chance.
+   * Spells use a magic-biased variant that still compares `Accuracy` versus `Evasion`, but also layers in a smaller `INT` versus `WIS` pressure term before clamping the final hit chance.
    * If the hit roll fails, the action is surfaced as a `dodge` event in the log/UI.
 5. **Parry Check:**
    * `Parry` applies only to `melee + physical` attacks.
    * Ranged physical attacks such as `Piercing Shot` can still miss or be dodged, but they cannot be parried by default.
-   * If a parry succeeds, the hit is fully negated and on-hit resource triggers do not fire.
+   * If a parry succeeds, the hit is fully negated.
 6. **Damage Roll:**
    * Clerics use their `Magic Damage` stat when attacking.
    * Warriors and Archers use their `Physical Damage` stat.
 7. **Critical Hit Check:** The unit's `Crit Chance` (base 5%, boosted by DEX) is rolled. If successful, damage is multiplied.
    * Archers have a `2.0x` Crit Multiplier.
    * All other classes have a `1.5x` Crit Multiplier.
-8. **Mitigation:** The final incoming damage is reduced based on the action's specific `DamageElement` tag. If the element is `physical`, damage is reduced by subtracting the target's `Armor` value. If the element is magical (e.g. `light`, `fire`), damage is reduced by a percentage equal to the target's corresponding elemental resistance (minimum 1 damage).
-9. **Resource Triggers:** Warrior Rage generation now happens only on landed hits or when a Warrior is actually hit. Dodged or parried attacks do not grant Rage.
+8. **Mitigation:** The final incoming damage is reduced based on the action's specific `DamageElement` tag. If the element is `physical`, damage is reduced with a diminishing-return armor curve: `rawDamage * (100 / (100 + armor * 2))`. If the element is magical (e.g. `light`, `fire`), damage is reduced by a percentage equal to the target's corresponding elemental resistance (minimum 1 damage).
+9. **Resource Triggers:** Warrior Rage generation now happens after any resolved Warrior attack action, including dodges or parries, plus whenever a Warrior takes damage. This keeps Rage tied to combat participation without requiring every melee swing to connect.
 
 Cleric `Smite` is the first shipped non-physical attack in this system and is tagged as `light`, so it already respects Light resistance. Additional elemental attacks can reuse the same mitigation path in future expansions.
 
@@ -60,9 +60,9 @@ Cleric `Smite` is the first shipped non-physical attack in this system and is ta
 
 The first deeper-combat pass uses bounded formulas to stay stable under long-term idle scaling:
 
-* **Physical / Ranged Hit Chance:** `clamp(72%, 97%, 84% + (attacker.Accuracy - defender.Evasion) * 0.2%)`
-* **Spell Hit Chance:** `clamp(75%, 98%, 86% + ((attacker.Accuracy + attacker.INT) - (defender.Evasion + defender.WIS)) * 0.18%)`
-* **Parry Chance:** `clamp(0%, 30%, 6% + (defender.Parry - attacker.Accuracy * 0.25) * 0.3%)`
+* **Physical / Ranged Hit Chance:** `clamp(72%, 97%, 82% + (attacker.Accuracy - defender.Evasion) * 0.2%)`
+* **Spell Hit Chance:** `clamp(74%, 96%, 82% + (attacker.Accuracy - defender.Evasion) * 0.16% + (attacker.INT - defender.WIS) * 0.08%)`
+* **Parry Chance:** `clamp(0%, 25%, 4% + (defender.Parry - attacker.Accuracy * 0.3) * 0.25%)`
 
 ### Combat Readability
 

--- a/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
+++ b/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
@@ -26,7 +26,7 @@ When an EXP threshold is reached, the hero levels up, deducting the required amo
 
 * **Warrior:** +2 STR, +2 VIT, +1 DEX, +1 INT, +1 WIS
 * **Cleric:** +2 INT, +2 WIS, +1 STR, +1 VIT, +1 DEX
-* **Archer:** +2 DEX, +1 STR, +1 VIT, +1 INT, +1 WIS, (and a 50% chance for an extra +1 DEX)
+* **Archer:** +2 DEX, +1 STR, +1 VIT, +1 INT, +1 WIS
 
 ### Persistent Gold Upgrades
 

--- a/src/game/engine/simulation.test.ts
+++ b/src/game/engine/simulation.test.ts
@@ -1,15 +1,53 @@
 import Decimal from "decimal.js";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { createEnemy, createHero } from "../entity";
 
-import { createEncounter, createInitialGameState, getEncounterSize, isBossFloor, simulateTick } from "./simulation";
+import {
+    applyPhysicalMitigation,
+    createEncounter,
+    createInitialGameState,
+    createSequenceRandomSource,
+    getEncounterSize,
+    getPhysicalHitChance,
+    getSpellHitChance,
+    isBossFloor,
+    simulateTick,
+} from "./simulation";
+
+const advanceUntilLogs = (state = createInitialGameState(), randomSource = createSequenceRandomSource(0), logCount = 1) => {
+    let nextState = state;
+    let result = simulateTick(nextState, randomSource);
+    nextState = result.state;
+    let safetyCounter = 0;
+
+    while (nextState.combatLog.length < logCount && safetyCounter < 500) {
+        result = simulateTick(nextState, randomSource);
+        nextState = result.state;
+        safetyCounter += 1;
+    }
+
+    if (safetyCounter >= 500) {
+        throw new Error("Expected combat log updates before safety limit.");
+    }
+
+    return result;
+};
+
+const advanceTicks = (state = createInitialGameState(), randomSource = createSequenceRandomSource(0), tickCount = 1) => {
+    let nextState = state;
+    let result = simulateTick(nextState, randomSource);
+    nextState = result.state;
+
+    for (let tick = 1; tick < tickCount; tick += 1) {
+        result = simulateTick(nextState, randomSource);
+        nextState = result.state;
+    }
+
+    return result;
+};
 
 describe("simulation engine", () => {
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
-
     it("scales standard encounters by floor instead of player party size", () => {
         expect(getEncounterSize(1)).toBe(1);
         expect(getEncounterSize(6)).toBe(2);
@@ -38,18 +76,13 @@ describe("simulation engine", () => {
         const startingHp = enemy.currentHp;
         const expectedDamage = cleric.magicDamage.times(1 - enemy.resistances.light);
 
-        vi.spyOn(Math, "random")
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0.9)
-            .mockReturnValue(0.9);
-
         const result = simulateTick(
             createInitialGameState({
                 party: [cleric],
                 enemies: [enemy],
                 combatLog: [],
             }),
+            createSequenceRandomSource(0, 0, 0.9),
         );
 
         expect(result.state.enemies[0].currentHp.eq(startingHp.minus(expectedDamage))).toBe(true);
@@ -65,19 +98,17 @@ describe("simulation engine", () => {
         enemy.evasionRating = 500;
         const startingHp = enemy.currentHp;
 
-        vi.spyOn(Math, "random")
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0.95);
-
         const result = simulateTick(
             createInitialGameState({
                 party: [warrior],
                 enemies: [enemy],
                 combatLog: [],
             }),
+            createSequenceRandomSource(0, 0.95),
         );
 
         expect(result.state.enemies[0].currentHp.eq(startingHp)).toBe(true);
+        expect(result.state.party[0].currentResource.toNumber()).toBe(8);
         expect(result.state.combatLog[0]).toMatch(/dodges/i);
         expect(result.state.combatEvents.some((event) => event.kind === "dodge")).toBe(true);
     });
@@ -92,20 +123,17 @@ describe("simulation engine", () => {
         enemy.parryRating = 200;
         const startingHp = enemy.currentHp;
 
-        vi.spyOn(Math, "random")
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0.2);
-
         const result = simulateTick(
             createInitialGameState({
                 party: [warrior],
                 enemies: [enemy],
                 combatLog: [],
             }),
+            createSequenceRandomSource(0, 0, 0.2),
         );
 
         expect(result.state.enemies[0].currentHp.eq(startingHp)).toBe(true);
+        expect(result.state.party[0].currentResource.toNumber()).toBe(8);
         expect(result.state.combatLog[0]).toMatch(/parries/i);
         expect(result.state.combatEvents.some((event) => event.kind === "parry")).toBe(true);
     });
@@ -120,21 +148,16 @@ describe("simulation engine", () => {
         enemy.critChance = 0;
         const startingHp = warrior.currentHp;
 
-        vi.spyOn(Math, "random")
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0.2);
-
         const result = simulateTick(
             createInitialGameState({
                 party: [warrior],
                 enemies: [enemy],
                 combatLog: [],
             }),
+            createSequenceRandomSource(0, 0, 0.2),
         );
 
         expect(result.state.party[0].currentHp.eq(startingHp)).toBe(true);
-        expect(result.state.combatLog[0]).toMatch(/parries/i);
         expect(result.state.combatLog[0]).toMatch(/Brom parries Sewer Rat Lv1's Attack!/);
         expect(result.state.combatEvents.some((event) => event.kind === "parry" && event.targetId === warrior.id)).toBe(true);
     });
@@ -149,18 +172,13 @@ describe("simulation engine", () => {
         enemy.parryRating = 999;
         const startingHp = enemy.currentHp;
 
-        vi.spyOn(Math, "random")
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0.9)
-            .mockReturnValue(0.9);
-
         const result = simulateTick(
             createInitialGameState({
                 party: [archer],
                 enemies: [enemy],
                 combatLog: [],
             }),
+            createSequenceRandomSource(0, 0, 0.9),
         );
 
         expect(result.state.enemies[0].currentHp.lt(startingHp)).toBe(true);
@@ -168,17 +186,15 @@ describe("simulation engine", () => {
         expect(result.state.combatLog[0]).not.toMatch(/parries/i);
     });
 
-    it("only grants warrior resource on landed hits", () => {
+    it("does not let Rage Strike be parried", () => {
         const warrior = createHero("hero_1", "Brom", "Warrior");
         warrior.actionProgress = 99;
-        warrior.currentResource = new Decimal(0);
+        warrior.critChance = 0;
+        warrior.currentResource = new Decimal(40);
 
         const enemy = createEnemy(1, "enemy_1");
-        enemy.evasionRating = 500;
-
-        vi.spyOn(Math, "random")
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0.95);
+        enemy.parryRating = 999;
+        const startingHp = enemy.currentHp;
 
         const result = simulateTick(
             createInitialGameState({
@@ -186,9 +202,107 @@ describe("simulation engine", () => {
                 enemies: [enemy],
                 combatLog: [],
             }),
+            createSequenceRandomSource(0, 0, 0.9),
         );
 
-        expect(result.state.party[0].currentResource.eq(0)).toBe(true);
+        expect(result.state.enemies[0].currentHp.lt(startingHp)).toBe(true);
+        expect(result.state.combatLog[0]).toMatch(/rage strike/i);
+        expect(result.state.combatLog[0]).not.toMatch(/parries/i);
+    });
+
+    it("uses a diminishing-return armor curve for physical mitigation", () => {
+        expect(applyPhysicalMitigation(new Decimal(40), new Decimal(20)).toDecimalPlaces(2).toNumber()).toBeCloseTo(28.57, 2);
+        expect(applyPhysicalMitigation(new Decimal(40), new Decimal(80)).toDecimalPlaces(2).toNumber()).toBeCloseTo(15.38, 2);
+    });
+
+    it("keeps spell hit only modestly above physical hit for the same matchup", () => {
+        const warrior = createHero("hero_1", "Brom", "Warrior");
+        const cleric = createHero("hero_2", "Ayla", "Cleric");
+        const enemy = createEnemy(5, "enemy_5");
+
+        const physicalHit = getPhysicalHitChance(warrior, enemy);
+        const spellHit = getSpellHitChance(cleric, enemy);
+
+        expect(spellHit).toBeGreaterThan(physicalHit);
+        expect(spellHit - physicalHit).toBeLessThan(0.08);
+    });
+
+    it("lets warriors reach Rage Strike within a few exchanged actions", () => {
+        const warrior = createHero("hero_1", "Brom", "Warrior");
+        warrior.critChance = 0;
+        warrior.parryRating = 0;
+
+        const enemy = createEnemy(1, "enemy_1");
+        enemy.actionProgress = 99;
+        enemy.critChance = 0;
+        enemy.currentHp = new Decimal(10_000);
+
+        const rolls: number[] = [];
+        for (let index = 0; index < 400; index += 1) {
+            rolls.push(0, 0, 0.9, 0.9);
+        }
+
+        const result = advanceTicks(
+            createInitialGameState({
+                party: [warrior],
+                enemies: [enemy],
+                combatLog: [],
+            }),
+            createSequenceRandomSource(...rolls),
+            180,
+        );
+
+        expect(result.state.combatLog.some((entry) => /rage strike/i.test(entry))).toBe(true);
+    });
+
+    it("stops archers from sustaining Piercing Shot every action after the opening pool", () => {
+        const archer = createHero("hero_1", "Vera", "Archer");
+        const enemy = createEnemy(1, "enemy_1");
+        enemy.currentHp = new Decimal(10_000);
+        enemy.actionProgress = -999;
+
+        const rolls: number[] = [];
+        for (let index = 0; index < 60; index += 1) {
+            rolls.push(0, 0, 0.9);
+        }
+
+        let result = createInitialGameState({
+            party: [archer],
+            enemies: [enemy],
+            combatLog: [],
+        });
+
+        for (let actionCount = 0; actionCount < 6; actionCount += 1) {
+            result = advanceUntilLogs(result, createSequenceRandomSource(...rolls), actionCount + 1).state;
+        }
+
+        const recentLogs = result.combatLog.slice(0, 6).join("\n");
+
+        expect(recentLogs).toMatch(/piercing shot/i);
+        expect(recentLogs).toMatch(/uses Attack/i);
+    });
+
+    it("levels archers with fixed dex growth only", () => {
+        const archer = createHero("hero_1", "Vera", "Archer");
+        archer.exp = new Decimal(99);
+        archer.actionProgress = 99;
+        archer.critChance = 0;
+
+        const enemy = createEnemy(10, "enemy_10");
+        enemy.currentHp = new Decimal(1);
+
+        const result = simulateTick(
+            createInitialGameState({
+                floor: 10,
+                party: [archer],
+                enemies: [enemy],
+                combatLog: [],
+            }),
+            createSequenceRandomSource(0, 0, 0.9),
+        );
+
+        expect(result.state.party[0].level).toBe(2);
+        expect(result.state.party[0].attributes.dex).toBe(14);
     });
 
     it("expires transient combat events as ticks advance", () => {
@@ -224,11 +338,6 @@ describe("simulation engine", () => {
         const enemy = createEnemy(4, "enemy_4");
         enemy.currentHp = new Decimal(1);
 
-        vi.spyOn(Math, "random")
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0)
-            .mockReturnValueOnce(0.9);
-
         const result = simulateTick(
             createInitialGameState({
                 floor: 4,
@@ -236,6 +345,7 @@ describe("simulation engine", () => {
                 enemies: [enemy],
                 combatLog: [],
             }),
+            createSequenceRandomSource(0, 0, 0.9),
         );
 
         expect(result.state.enemies[0].currentHp.eq(0)).toBe(true);

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -8,15 +8,23 @@ import type { CombatEvent, GameState } from "../store/types";
 export const GAME_TICK_RATE = 20;
 export const GAME_TICK_MS = 1000 / GAME_TICK_RATE;
 export const ATB_RATE = 2;
+export const DEX_ATB_RATE = 0.06;
+export const WARRIOR_RAGE_STRIKE_COST = 40;
+export const WARRIOR_RAGE_PER_ATTACK = 8;
+export const WARRIOR_RAGE_WHEN_HIT = 5;
+export const ARCHER_PIERCING_SHOT_COST = 35;
+export const ARCHER_PIERCING_SHOT_CRIT_BONUS = 0.15;
+export const ARCHER_CUNNING_REGEN_PER_TICK = 0.75;
+export const ARMOR_MITIGATION_SCALE = 2;
 
 const SKILL_BANNER_TICKS = GAME_TICK_RATE;
 const COMBAT_EVENT_TICKS = Math.round(GAME_TICK_RATE * 1.4);
 const COMBAT_LOG_LIMIT = 10;
 const MIN_PHYSICAL_HIT_CHANCE = 0.72;
 const MAX_PHYSICAL_HIT_CHANCE = 0.97;
-const MIN_SPELL_HIT_CHANCE = 0.75;
-const MAX_SPELL_HIT_CHANCE = 0.98;
-const MAX_PARRY_CHANCE = 0.3;
+const MIN_SPELL_HIT_CHANCE = 0.74;
+const MAX_SPELL_HIT_CHANCE = 0.96;
+const MAX_PARRY_CHANCE = 0.25;
 let combatEventSequence = 0;
 
 type DamageElement = "physical" | keyof Entity["resistances"];
@@ -38,6 +46,30 @@ export interface SimulationResult {
     state: GameState;
     outcome: SimulationOutcome;
 }
+
+export interface SimulationRandomSource {
+    next: () => number;
+}
+
+const defaultRandomSource: SimulationRandomSource = {
+    next: () => Math.random(),
+};
+
+export const createSequenceRandomSource = (...rolls: number[]): SimulationRandomSource => {
+    let index = 0;
+
+    return {
+        next: () => {
+            if (rolls.length === 0) {
+                return 0;
+            }
+
+            const nextRoll = rolls[Math.min(index, rolls.length - 1)];
+            index += 1;
+            return nextRoll;
+        },
+    };
+};
 
 export const isBossFloor = (floor: number) => floor % 10 === 0;
 
@@ -171,22 +203,29 @@ export const getPhysicalHitChance = (attacker: Entity, defender: Entity) =>
     clampChance(
         MIN_PHYSICAL_HIT_CHANCE,
         MAX_PHYSICAL_HIT_CHANCE,
-        0.84 + ((attacker.accuracyRating - defender.evasionRating) * 0.002),
+        0.82 + ((attacker.accuracyRating - defender.evasionRating) * 0.002),
     );
 
 export const getSpellHitChance = (attacker: Entity, defender: Entity) =>
     clampChance(
         MIN_SPELL_HIT_CHANCE,
         MAX_SPELL_HIT_CHANCE,
-        0.86 + (((attacker.accuracyRating + attacker.attributes.int) - (defender.evasionRating + defender.attributes.wis)) * 0.0018),
+        0.82
+            + ((attacker.accuracyRating - defender.evasionRating) * 0.0016)
+            + ((attacker.attributes.int - defender.attributes.wis) * 0.0008),
     );
 
 export const getParryChance = (attacker: Entity, defender: Entity) =>
     clampChance(
         0,
         MAX_PARRY_CHANCE,
-        0.06 + ((defender.parryRating - (attacker.accuracyRating * 0.25)) * 0.003),
+        0.04 + ((defender.parryRating - (attacker.accuracyRating * 0.3)) * 0.0025),
     );
+
+export const applyPhysicalMitigation = (rawDamage: Decimal, armor: Decimal) => {
+    const mitigatedDamage = rawDamage.times(100).div(new Decimal(100).plus(armor.times(ARMOR_MITIGATION_SCALE)));
+    return Decimal.max(1, mitigatedDamage);
+};
 
 const createCombatEvent = (event: Omit<CombatEvent, "id">): CombatEvent => {
     combatEventSequence += 1;
@@ -226,25 +265,25 @@ const getDamageAction = (entity: Entity): DamageAction => {
         };
     }
 
-    if (!entity.isEnemy && entity.class === "Warrior" && entity.currentResource.gte(50)) {
-        entity.currentResource = entity.currentResource.minus(50);
+    if (!entity.isEnemy && entity.class === "Warrior" && entity.currentResource.gte(WARRIOR_RAGE_STRIKE_COST)) {
+        entity.currentResource = entity.currentResource.minus(WARRIOR_RAGE_STRIKE_COST);
         action = {
             ...action,
             name: "Rage Strike",
             damage: entity.physicalDamage.times(2),
             damageElement: "physical",
             deliveryType: "melee",
-            canParry: true,
+            canParry: false,
         };
-    } else if (!entity.isEnemy && entity.class === "Archer" && entity.currentResource.gte(25)) {
-        entity.currentResource = entity.currentResource.minus(25);
+    } else if (!entity.isEnemy && entity.class === "Archer" && entity.currentResource.gte(ARCHER_PIERCING_SHOT_COST)) {
+        entity.currentResource = entity.currentResource.minus(ARCHER_PIERCING_SHOT_COST);
         action = {
             ...action,
             name: "Piercing Shot",
             damage: entity.physicalDamage.times(1.6),
             damageElement: "physical",
             deliveryType: "ranged",
-            critChance: Math.min(1, entity.critChance + 0.25),
+            critChance: Math.min(1, entity.critChance + ARCHER_PIERCING_SHOT_CRIT_BONUS),
             canParry: false,
         };
     }
@@ -256,7 +295,15 @@ const getDamageAction = (entity: Entity): DamageAction => {
     return action;
 };
 
-export const simulateTick = (state: GameState): SimulationResult => {
+const grantWarriorAttackRage = (entity: Entity) => {
+    if (entity.class !== "Warrior") {
+        return;
+    }
+
+    entity.currentResource = Decimal.min(entity.maxResource, entity.currentResource.plus(WARRIOR_RAGE_PER_ATTACK));
+};
+
+export const simulateTick = (state: GameState, randomSource: SimulationRandomSource = defaultRandomSource): SimulationResult => {
     const draft: GameState = {
         ...state,
         party: state.party.map(cloneEntity),
@@ -330,10 +377,10 @@ export const simulateTick = (state: GameState): SimulationResult => {
         }
 
         const hasteBonus = draft.prestigeUpgrades.gameSpeed * 0.1; // +10% speed up per level
-        entity.actionProgress += (ATB_RATE + (entity.attributes.dex * 0.1)) * (1 + hasteBonus);
+        entity.actionProgress += (ATB_RATE + (entity.attributes.dex * DEX_ATB_RATE)) * (1 + hasteBonus);
 
         if (entity.class === "Cleric" || entity.class === "Archer") {
-            const regen = entity.class === "Cleric" ? entity.attributes.wis * 0.5 : 2;
+            const regen = entity.class === "Cleric" ? entity.attributes.wis * 0.5 : ARCHER_CUNNING_REGEN_PER_TICK;
             entity.currentResource = entity.currentResource.plus(regen);
             if (entity.currentResource.gt(entity.maxResource)) {
                 entity.currentResource = entity.maxResource;
@@ -378,7 +425,7 @@ export const simulateTick = (state: GameState): SimulationResult => {
             return;
         }
 
-        const target = aliveTargets[Math.floor(Math.random() * aliveTargets.length)];
+        const target = aliveTargets[Math.floor(randomSource.next() * aliveTargets.length)];
         const action = getDamageAction(entity);
 
         setActiveSkill(entity, action.name);
@@ -387,7 +434,8 @@ export const simulateTick = (state: GameState): SimulationResult => {
             ? getSpellHitChance(entity, target)
             : getPhysicalHitChance(entity, target);
 
-        if (action.canDodge && Math.random() >= hitChance) {
+        if (action.canDodge && randomSource.next() >= hitChance) {
+            grantWarriorAttackRage(entity);
             queueCombatEvent({
                 sourceId: entity.id,
                 targetId: target.id,
@@ -399,7 +447,8 @@ export const simulateTick = (state: GameState): SimulationResult => {
             return;
         }
 
-        if (action.canParry && action.deliveryType === "melee" && action.damageElement === "physical" && Math.random() < getParryChance(entity, target)) {
+        if (action.canParry && action.deliveryType === "melee" && action.damageElement === "physical" && randomSource.next() < getParryChance(entity, target)) {
+            grantWarriorAttackRage(entity);
             queueCombatEvent({
                 sourceId: entity.id,
                 targetId: target.id,
@@ -412,7 +461,7 @@ export const simulateTick = (state: GameState): SimulationResult => {
         }
 
         let damage = action.damage;
-        const isCrit = Math.random() < action.critChance;
+        const isCrit = randomSource.next() < action.critChance;
         if (isCrit) {
             damage = damage.times(entity.critDamage);
             queueCombatEvent({
@@ -427,7 +476,7 @@ export const simulateTick = (state: GameState): SimulationResult => {
 
         let finalDamage = damage;
         if (action.damageElement === "physical") {
-            finalDamage = damage.minus(target.armor);
+            finalDamage = applyPhysicalMitigation(damage, target.armor);
         } else {
             finalDamage = damage.times(1 - target.resistances[action.damageElement]);
         }
@@ -444,12 +493,10 @@ export const simulateTick = (state: GameState): SimulationResult => {
             ttlTicks: COMBAT_EVENT_TICKS,
         });
 
-        if (entity.class === "Warrior") {
-            entity.currentResource = Decimal.min(entity.maxResource, entity.currentResource.plus(10));
-        }
+        grantWarriorAttackRage(entity);
 
-        if (target.class === "Warrior" && target.currentHp.gt(0)) {
-            target.currentResource = Decimal.min(target.maxResource, target.currentResource.plus(5));
+        if (target.class === "Warrior") {
+            target.currentResource = Decimal.min(target.maxResource, target.currentResource.plus(WARRIOR_RAGE_WHEN_HIT));
         }
 
         logMessages.push(`${entity.name} uses ${action.name} on ${target.name} for ${finalDamage.floor().toString()}! ${isCrit ? "(CRIT)" : ""}`.trim());
@@ -504,7 +551,6 @@ export const simulateTick = (state: GameState): SimulationResult => {
                     nextHero.attributes.vit += 1;
                     nextHero.attributes.int += 1;
                     nextHero.attributes.wis += 1;
-                    nextHero.attributes.dex += Math.random() > 0.5 ? 1 : 0;
                 }
 
                 nextHero = recalculateEntity(nextHero, draft.metaUpgrades, draft.prestigeUpgrades);

--- a/src/game/entity.test.ts
+++ b/src/game/entity.test.ts
@@ -36,8 +36,8 @@ describe("entity model", () => {
     it("derives accuracy, evasion, and parry ratings from existing attributes", () => {
         const warrior = createHero("hero_1", "Brom", "Warrior");
 
-        expect(warrior.accuracyRating).toBe(63);
-        expect(warrior.evasionRating).toBeCloseTo(45.5);
+        expect(warrior.accuracyRating).toBeCloseTo(60.5);
+        expect(warrior.evasionRating).toBeCloseTo(43);
         expect(warrior.parryRating).toBeCloseTo(18.75);
     });
 

--- a/src/game/entity.ts
+++ b/src/game/entity.ts
@@ -13,6 +13,7 @@ export interface PrestigeUpgrades {
     costReducer: number;
     hpMultiplier: number;
     gameSpeed: number;
+    xpMultiplier?: number;
 }
 
 export interface Attributes {
@@ -99,12 +100,12 @@ export const STAT_MULTS = {
     RESOURCE_PER_INT: 5,
     CRIT_CHANCE_PER_DEX: 0.005, // 0.5% per Dex
     RESIST_PER_WIS: 0.01, // 1% per Wis
-    ACCURACY_PER_DEX: 2,
+    ACCURACY_PER_DEX: 1.5,
     ACCURACY_PER_INT: 1,
-    EVASION_PER_DEX: 1.5,
+    EVASION_PER_DEX: 1,
     EVASION_PER_WIS: 1,
-    PARRY_PER_STR: 1.5,
-    PARRY_PER_DEX: 0.75,
+    PARRY_PER_STR: 1.75,
+    PARRY_PER_DEX: 0.25,
 };
 
 // Start Stats Helpers


### PR DESCRIPTION
Closes #58.

## Summary
This rebalances the hit-resolution combat pass so Dexterity no longer dominates offense, defense, and speed at the same time, while Warrior and Archer resource spenders behave like real burst windows instead of passive defaults.

The main player-facing effect is that Warrior starts are no longer punished by the full melee tax of miss plus parry plus flat armor subtraction, Archers still feel fast and accurate without getting near-permanent `Piercing Shot` uptime, and Cleric spell reliability stays strong without crowding out the rest of the roster.

## Root Cause
Issue #58 came from a few systems stacking in the same direction after accuracy, evasion, and parry were introduced:

- DEX was simultaneously driving accuracy, evasion, crit, and ATB speed too hard.
- Physical melee had more failure points than spell damage and also fell off sharply against flat armor spikes.
- Archer Cunning regeneration was high enough that `Piercing Shot` behaved like the default attack.
- Warrior Rage generation depended too much on successful landed hits, which made the class feel worse exactly when accuracy and parry pressure were highest.

## Fix
This PR rebalances the combat model in a few coordinated places instead of trying to solve the issue with one-off class buffs:

- reduced DEX weighting in derived stats and ATB speed, and shifted more parry value onto STR
- updated physical hit, spell hit, and parry formulas so spell reliability stays somewhat better without becoming a separate always-safe lane
- replaced flat physical armor subtraction with a diminishing-return mitigation curve to stop progression spikes from collapsing melee damage to near-1 values
- changed Warrior Rage pacing so resolved attacks grant Rage, lowered `Rage Strike` to 40 cost, and made `Rage Strike` unparryable
- changed Archer pacing so `Piercing Shot` costs more, gains less bonus crit chance, and is no longer sustained every action after the opening pool
- removed Archer's random bonus DEX level-up roll so class growth is fixed and easier to balance
- updated the architecture decision records so the docs match the shipped formulas and progression rules

This keeps the earlier fixes from #56 and #57 intact rather than reopening enemy delivery-type behavior or milestone tuning in this PR.

## Validation
I verified the change with targeted combat checks first and then a full repo pass:

- `npm test -- src/game/engine/simulation.test.ts`
- `npm test -- src/game/entity.test.ts`
- `npm test -- src/game/gameState.integration.test.tsx`
- `npm test -- src/game/store/gameStore.test.ts`
- `npm test`
- `npm run build`

The updated tests now cover the new armor curve, fixed Archer level growth, Warrior `Rage Strike` cadence and unparryable behavior, Archer spender uptime, and the tighter spell-vs-physical hit-rate gap.
