### PR TITLE
Add bounded penetration and tenacity combat scaling

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/002-attributes-and-stats.md
+++ b/docs/ARCHITECTURE/gamedecisions/002-attributes-and-stats.md
@@ -37,8 +37,13 @@ When a unit is created or levels up, their total attributes are summed and used 
 *   **Accuracy Rating:** `50 + (DEX * 1.5) + (INT * 1)`
 *   **Evasion Rating:** `35 + (DEX * 1.0) + (WIS * 1)`
 *   **Parry Rating:** `(STR * 1.75) + (DEX * 0.25)`
+*   **Armor Penetration:** `(STR * 1.0) + (DEX * 0.5)`
+*   **Elemental Penetration:** `(INT * 1.0) + (WIS * 0.5)`
+*   **Tenacity:** `(VIT * 0.75) + (WIS * 1.0)`
 
 These additional ratings are intentionally coupled to the same five core attributes instead of introducing a sixth or seventh combat stat. `DEX` now contributes to both offensive precision and defensive footwork, `STR` helps melee defense through parry, and `WIS` helps magical awareness and avoidance pressure.
+
+The newer long-term scaling ratings follow the same philosophy: `STR` and `DEX` feed physical mitigation bypass, `INT` and `WIS` feed magical mitigation bypass, and `VIT` plus `WIS` provide a bounded anti-spike defense through `Tenacity`.
 
 ### Classes & Secondary Resources
 Classes use secondary resources to cast powerful abilities (future-proofing) or sustain basic actions:
@@ -53,6 +58,8 @@ To prevent infinite scaling breaking the game logic:
 *   **Physical / Ranged Hit Chance:** Uses `Accuracy Rating` vs `Evasion Rating`, then clamps to a floor of `72%` and a ceiling of `97%`.
 *   **Spell Hit Chance:** Uses a magic-biased contest of `Accuracy + INT` versus `Evasion + WIS`, then clamps to `75%` to `98%`.
 *   **Parry Chance:** Applies only to `melee + physical` attacks and is capped at `30%`.
+*   **Penetration Reduction:** Both `Armor Penetration` and `Elemental Penetration` convert through `min(60%, penetration / (penetration + 60))`, so mitigation bypass scales with diminishing returns and cannot erase more than 60% of the target's armor or resistance.
+*   **Tenacity Reduction:** `Tenacity` converts through `min(60%, tenacity / (tenacity + 80))`, so it can only reduce a portion of incoming critical bonus damage.
 
 ### Combat Role Implications
 The new derived ratings reinforce class roles without adding bespoke per-class rules:
@@ -61,7 +68,8 @@ The new derived ratings reinforce class roles without adding bespoke per-class r
 * **Cleric:** gains steadier spell reliability from INT while WIS continues to scale elemental resistance and magical defense.
 * **Archer:** still receives the strongest `Accuracy` and `Evasion` growth through DEX, but the lighter DEX weighting reduces all-in-one stat stacking and keeps the class focused on agility rather than passive durability.
 * **Monsters:** inherit the same formulas, which keeps enemy combat behavior scalable without a separate balance table for hit logic. Archetype bias changes which attributes are emphasized, but not how those attributes convert into combat stats.
+* **Tenacity:** currently dampens incoming crit spikes only. It is intentionally reserved as the future hook for status duration/chance resistance once elemental status effects ship.
 
 ## Consequences
 *   **Easier:** Designing items or buffs that grant `+X STR`, `+X DEX`, or `+X WIS` is clearer because those attributes now affect both raw throughput and hit-resolution outcomes.
-*   **Difficult:** Because the same attributes now scale multiple combat layers, balance drift is easier to introduce. Future penetration, status, or tenacity systems should be tuned carefully so DEX- or WIS-stacking does not crowd out other builds.
+*   **Difficult:** Because the same attributes now scale multiple combat layers, balance drift is easier to introduce. Penetration and Tenacity help long-term scaling stay interesting, but future status systems still need to avoid turning `WIS` into an all-purpose answer stat.

--- a/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
+++ b/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
@@ -52,9 +52,10 @@ Currently, action resolution uses a lightweight class-aware ruleset:
 7. **Critical Hit Check:** The unit's `Crit Chance` (base 5%, boosted by DEX) is rolled. If successful, damage is multiplied.
    * Archers have a `2.0x` Crit Multiplier.
    * All other classes have a `1.5x` Crit Multiplier.
-8. **Mitigation:** The final incoming damage is reduced based on the action's specific `DamageElement` tag. If the element is `physical`, damage is reduced with a diminishing-return armor curve: `rawDamage * (100 / (100 + armor * 2))`. If the element is magical (e.g. `light`, `fire`), damage is reduced by a percentage equal to the target's corresponding elemental resistance (minimum 1 damage).
+8. **Mitigation:** The final incoming damage is reduced based on the action's specific `DamageElement` tag. If the element is `physical`, the attacker's `Armor Penetration` first converts through `min(60%, penetration / (penetration + 60))` and reduces the target's effective armor by that proportion, then damage is reduced with the existing diminishing-return armor curve: `rawDamage * (100 / (100 + effectiveArmor * 2))`. If the element is magical (e.g. `light`, `fire`), the attacker's `Elemental Penetration` uses the same bounded conversion to reduce the target's effective elemental resistance before the percentage-based resistance reduction is applied. Minimum damage remains `1`.
 9. **Protection Effects:** `Ward Ally` is a lightweight support-only protection effect. It reduces the next damaging hit against the warded target by `35%`, then expires immediately. This gives enemy support units an ally-protection hook without introducing a full buff/debuff framework yet.
 10. **Resource Triggers:** Warrior Rage generation now happens after any resolved Warrior attack action, including dodges or parries, plus whenever a Warrior takes damage. This keeps Rage tied to combat participation without requiring every melee swing to connect.
+11. **Tenacity:** If the action crits, the defender's `Tenacity` dampens only the bonus portion of the crit multiplier through `min(60%, tenacity / (tenacity + 80))`. This means Tenacity does not change crit chance and cannot turn a crit into a normal hit; it only softens long-term crit spikes. The same stat is reserved as the future hook for status-duration or status-chance resistance.
 
 Cleric `Smite` is the first shipped non-physical attack in this system and is tagged as `light`, so it already respects Light resistance. Additional elemental attacks can reuse the same mitigation path in future expansions.
 
@@ -77,6 +78,8 @@ The first deeper-combat pass uses bounded formulas to stay stable under long-ter
 * **Physical / Ranged Hit Chance:** `clamp(72%, 97%, 82% + (attacker.Accuracy - defender.Evasion) * 0.2%)`
 * **Spell Hit Chance:** `clamp(74%, 96%, 82% + (attacker.Accuracy - defender.Evasion) * 0.16% + (attacker.INT - defender.WIS) * 0.08%)`
 * **Parry Chance:** `clamp(0%, 25%, 4% + (defender.Parry - attacker.Accuracy * 0.3) * 0.25%)`
+* **Penetration Reduction:** `min(60%, penetration / (penetration + 60))`
+* **Tenacity Reduction:** `min(60%, tenacity / (tenacity + 80))`
 
 ### Combat Readability
 
@@ -91,7 +94,7 @@ To support higher-entity encounters (up to five party members and five enemies),
 * **Living-first ordering:** living entities are listed before defeated ones so the actionable combat state is always near the top of each roster.
 * **Compact bars with preserved scanability:** HP, resource, and action-readiness bars remain visible at reduced card density to avoid panel collapse at larger party sizes.
 * **Subtle role labels:** enemy roster cards and the encounter stage surface the current archetype in small uppercase labels so the player can read combat roles without adding a new panel or badge-heavy layout.
-* **On-demand derived detail:** secondary stat details (VIT/STR/DEX/INT/WIS) plus combat-facing ratings (`ACC`, `EVA`, `PAR`) and elemental resistances are available via portrait hover/focus tooltip rather than being permanently rendered in every card.
+* **On-demand derived detail:** secondary stat details (VIT/STR/DEX/INT/WIS) plus combat-facing ratings (`ACC`, `EVA`, `PAR`, `APEN`, `EPEN`, `TEN`) and elemental resistances are available via portrait hover/focus tooltip rather than being permanently rendered in every card.
 * **Scrollable roster columns:** party and enemy panels remain independently scrollable when total unit count exceeds available viewport height.
 * **Anchored combat log:** the middle-column log remains pinned to the bottom of the dungeon view while the encounter showcase keeps a stable footprint, so rapid kills or floor transitions do not cause the log panel to jump upward.
 * **Adjustable log depth:** players can still choose how much recent combat history to expose by expanding the log or dragging its resize handle upward for more visible entries.
@@ -104,4 +107,4 @@ The combat loop now advances through a provider-backed `zustand` store action (`
 ## Consequences
 
 * **Easier:** Combat is more readable and less deterministic. The same core attributes now support both raw throughput and hit-resolution gameplay without introducing a separate stat sheet, and enemy variety can increase without building a full parallel class roster.
-* **Difficult:** Because hit chance, dodge pressure, parry, elemental resistance, and now archetype targeting all scale from shared attributes, balance drift becomes easier to introduce at high levels. Future combat additions should prefer bounded formulas and explicit caps rather than open-ended avoidance stacking.
+* **Difficult:** Because hit chance, dodge pressure, parry, resistance, penetration, tenacity, and archetype targeting all scale from shared attributes, balance drift becomes easier to introduce at high levels. Future combat additions should prefer bounded formulas and explicit caps rather than open-ended avoidance stacking or mitigation bypass that fully invalidates earlier systems.

--- a/src/components/EntityRoster.test.tsx
+++ b/src/components/EntityRoster.test.tsx
@@ -29,6 +29,9 @@ const heroEntity: Entity = {
     accuracyRating: 66,
     evasionRating: 51,
     parryRating: 9,
+    armorPenetration: 9,
+    elementalPenetration: 13,
+    tenacity: 15.3,
     resistances: { fire: 0.2, water: 0.2, earth: 0.2, air: 0.2, light: 0.2, shadow: 0.2 },
     actionProgress: 25,
     activeSkill: "Casting Mend",
@@ -74,6 +77,9 @@ describe("EntityRoster", () => {
         expect(tooltip).toHaveTextContent(/acc\s*66/i);
         expect(tooltip).toHaveTextContent(/eva\s*51/i);
         expect(tooltip).toHaveTextContent(/par\s*9/i);
+        expect(tooltip).toHaveTextContent(/apen\s*9/i);
+        expect(tooltip).toHaveTextContent(/epen\s*13/i);
+        expect(tooltip).toHaveTextContent(/ten\s*15\.3/i);
         expect(tooltip).toHaveTextContent(/fire\s*20%/i);
         expect(tooltip).toHaveTextContent(/shadow\s*20%/i);
     });

--- a/src/components/EntityRoster.tsx
+++ b/src/components/EntityRoster.tsx
@@ -45,7 +45,11 @@ const resourceColorFor = (entity: Entity) => {
   return 'bg-purple-500';
 };
 
-const formatTooltipValue = (value: number) => {
+const formatTooltipValue = (value?: number) => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "0";
+  }
+
   if (Number.isInteger(value)) {
     return value.toString();
   }
@@ -62,6 +66,9 @@ const attributeStatsFor = (entity: Entity): TooltipStat[] => [
   { label: "ACC", value: Math.round(entity.accuracyRating).toString() },
   { label: "EVA", value: Math.round(entity.evasionRating).toString() },
   { label: "PAR", value: Math.round(entity.parryRating).toString() },
+  { label: "APEN", value: formatTooltipValue(entity.armorPenetration) },
+  { label: "EPEN", value: formatTooltipValue(entity.elementalPenetration) },
+  { label: "TEN", value: formatTooltipValue(entity.tenacity) },
 ];
 
 const resistanceStatsFor = (entity: Entity): TooltipStat[] => [

--- a/src/game/engine/simulation.test.ts
+++ b/src/game/engine/simulation.test.ts
@@ -4,12 +4,15 @@ import { describe, expect, it } from "vitest";
 import { createEnemy, createHero } from "../entity";
 
 import {
+    applyElementalMitigation,
     applyPhysicalMitigation,
     createEncounter,
     createInitialGameState,
     createSequenceRandomSource,
+    getEffectiveCritMultiplier,
     getEncounterSize,
     getPhysicalHitChance,
+    getPenetrationReduction,
     getSpellHitChance,
     isBossFloor,
     simulateTick,
@@ -84,7 +87,11 @@ describe("simulation engine", () => {
         enemy.resistances.light = 0.5;
 
         const startingHp = enemy.currentHp;
-        const expectedDamage = cleric.magicDamage.times(1 - enemy.resistances.light);
+        const expectedDamage = applyElementalMitigation(
+            cleric.magicDamage,
+            enemy.resistances.light,
+            cleric.elementalPenetration,
+        );
 
         const result = simulateTick(
             createInitialGameState({
@@ -397,6 +404,84 @@ describe("simulation engine", () => {
     it("uses a diminishing-return armor curve for physical mitigation", () => {
         expect(applyPhysicalMitigation(new Decimal(40), new Decimal(20)).toDecimalPlaces(2).toNumber()).toBeCloseTo(28.57, 2);
         expect(applyPhysicalMitigation(new Decimal(40), new Decimal(80)).toDecimalPlaces(2).toNumber()).toBeCloseTo(15.38, 2);
+    });
+
+    it("lets armor penetration increase physical damage without bypassing mitigation entirely", () => {
+        const rawDamage = new Decimal(40);
+        const armor = new Decimal(80);
+
+        const baseline = applyPhysicalMitigation(rawDamage, armor);
+        const penetrated = applyPhysicalMitigation(rawDamage, armor, 80);
+        const capped = applyPhysicalMitigation(rawDamage, armor, 10_000);
+
+        expect(penetrated.gt(baseline)).toBe(true);
+        expect(capped.gt(penetrated)).toBe(true);
+        expect(capped.lt(rawDamage)).toBe(true);
+    });
+
+    it("lets elemental penetration increase spell damage without nullifying resistance entirely", () => {
+        const rawDamage = new Decimal(50);
+        const resistance = 0.75;
+
+        const baseline = applyElementalMitigation(rawDamage, resistance);
+        const penetrated = applyElementalMitigation(rawDamage, resistance, 80);
+        const capped = applyElementalMitigation(rawDamage, resistance, 10_000);
+
+        expect(penetrated.gt(baseline)).toBe(true);
+        expect(capped.gt(penetrated)).toBe(true);
+        expect(capped.lt(rawDamage)).toBe(true);
+    });
+
+    it("caps penetration reduction under extreme stat inflation", () => {
+        expect(getPenetrationReduction(10_000)).toBe(0.6);
+        expect(getPenetrationReduction(0)).toBe(0);
+    });
+
+    it("lets tenacity reduce crit bonus damage without preventing crits", () => {
+        const archer = createHero("hero_1", "Vera", "Archer");
+        archer.actionProgress = 99;
+        archer.critChance = 1;
+        archer.critDamage = 2;
+        archer.currentResource = new Decimal(35);
+
+        const lowTenacityEnemy = createEnemy(1, "enemy_low_tenacity");
+        lowTenacityEnemy.armor = new Decimal(0);
+        lowTenacityEnemy.tenacity = 0;
+
+        const highTenacityEnemy = createEnemy(1, "enemy_high_tenacity");
+        highTenacityEnemy.armor = new Decimal(0);
+        highTenacityEnemy.tenacity = 200;
+
+        const lowTenacityResult = simulateTick(
+            createInitialGameState({
+                party: [archer],
+                enemies: [lowTenacityEnemy],
+                combatLog: [],
+            }),
+            createSequenceRandomSource(0, 0, 0),
+        );
+
+        const highTenacityResult = simulateTick(
+            createInitialGameState({
+                party: [{ ...archer, currentResource: new Decimal(35) }],
+                enemies: [highTenacityEnemy],
+                combatLog: [],
+            }),
+            createSequenceRandomSource(0, 0, 0),
+        );
+
+        const lowTenacityDamage = lowTenacityEnemy.currentHp.minus(lowTenacityResult.state.enemies[0].currentHp);
+        const highTenacityDamage = highTenacityEnemy.currentHp.minus(highTenacityResult.state.enemies[0].currentHp);
+
+        expect(lowTenacityResult.state.combatEvents.some((event) => event.kind === "crit")).toBe(true);
+        expect(highTenacityResult.state.combatEvents.some((event) => event.kind === "crit")).toBe(true);
+        expect(lowTenacityDamage.gt(highTenacityDamage)).toBe(true);
+    });
+
+    it("keeps crit multipliers above normal hits even against high tenacity", () => {
+        expect(getEffectiveCritMultiplier(2, 0)).toBeCloseTo(2);
+        expect(getEffectiveCritMultiplier(2, 10_000)).toBeCloseTo(1.4);
+        expect(getEffectiveCritMultiplier(1.5, 10_000)).toBeGreaterThan(1);
     });
 
     it("keeps spell hit only modestly above physical hit for the same matchup", () => {

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -24,6 +24,10 @@ export const ARCHER_PIERCING_SHOT_COST = 35;
 export const ARCHER_PIERCING_SHOT_CRIT_BONUS = 0.15;
 export const ARCHER_CUNNING_REGEN_PER_TICK = 0.75;
 export const ARMOR_MITIGATION_SCALE = 2;
+export const MAX_PENETRATION_REDUCTION = 0.6;
+export const PENETRATION_SOFTCAP = 60;
+export const MAX_TENACITY_REDUCTION = 0.6;
+export const TENACITY_SOFTCAP = 80;
 
 const SKILL_BANNER_TICKS = GAME_TICK_RATE;
 const COMBAT_EVENT_TICKS = Math.round(GAME_TICK_RATE * 1.4);
@@ -142,6 +146,9 @@ export const cloneEntity = (entity: Entity): Entity => ({
     accuracyRating: entity.accuracyRating ?? 0,
     evasionRating: entity.evasionRating ?? 0,
     parryRating: entity.parryRating ?? 0,
+    armorPenetration: entity.armorPenetration ?? 0,
+    elementalPenetration: entity.elementalPenetration ?? 0,
+    tenacity: entity.tenacity ?? 0,
     resistances: { ...entity.resistances },
     activeSkill: entity.activeSkill,
     activeSkillTicks: entity.activeSkillTicks,
@@ -157,7 +164,14 @@ export const prependCombatMessages = (combatLog: string[], ...messages: string[]
 };
 
 const hasValidCombatRatings = (entity: Partial<Entity>) => {
-    return [entity.accuracyRating, entity.evasionRating, entity.parryRating].every(
+    return [
+        entity.accuracyRating,
+        entity.evasionRating,
+        entity.parryRating,
+        entity.armorPenetration,
+        entity.elementalPenetration,
+        entity.tenacity,
+    ].every(
         (rating) => typeof rating === "number" && Number.isFinite(rating),
     );
 };
@@ -265,9 +279,43 @@ export const getParryChance = (attacker: Entity, defender: Entity) =>
         0.04 + ((defender.parryRating - (attacker.accuracyRating * 0.3)) * 0.0025),
     );
 
-export const applyPhysicalMitigation = (rawDamage: Decimal, armor: Decimal) => {
-    const mitigatedDamage = rawDamage.times(100).div(new Decimal(100).plus(armor.times(ARMOR_MITIGATION_SCALE)));
+export const getPenetrationReduction = (penetration: number) => {
+    if (penetration <= 0) {
+        return 0;
+    }
+
+    return Math.min(MAX_PENETRATION_REDUCTION, penetration / (penetration + PENETRATION_SOFTCAP));
+};
+
+export const getEffectiveArmor = (armor: Decimal, armorPenetration: number) => {
+    return armor.times(1 - getPenetrationReduction(armorPenetration));
+};
+
+export const applyPhysicalMitigation = (rawDamage: Decimal, armor: Decimal, armorPenetration = 0) => {
+    const mitigatedArmor = getEffectiveArmor(armor, armorPenetration);
+    const mitigatedDamage = rawDamage.times(100).div(new Decimal(100).plus(mitigatedArmor.times(ARMOR_MITIGATION_SCALE)));
     return Decimal.max(1, mitigatedDamage);
+};
+
+export const getEffectiveResistance = (resistance: number, elementalPenetration: number) => {
+    return resistance * (1 - getPenetrationReduction(elementalPenetration));
+};
+
+export const applyElementalMitigation = (rawDamage: Decimal, resistance: number, elementalPenetration = 0) => {
+    return Decimal.max(1, rawDamage.times(1 - getEffectiveResistance(resistance, elementalPenetration)));
+};
+
+export const getTenacityReduction = (tenacity: number) => {
+    if (tenacity <= 0) {
+        return 0;
+    }
+
+    return Math.min(MAX_TENACITY_REDUCTION, tenacity / (tenacity + TENACITY_SOFTCAP));
+};
+
+export const getEffectiveCritMultiplier = (critDamage: number, targetTenacity: number) => {
+    const critBonus = Math.max(0, critDamage - 1);
+    return 1 + (critBonus * (1 - getTenacityReduction(targetTenacity)));
 };
 
 const createCombatEvent = (event: Omit<CombatEvent, "id">): CombatEvent => {
@@ -697,7 +745,7 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
         let damage = action.damage;
         const isCrit = randomSource.next() < action.critChance;
         if (isCrit) {
-            damage = damage.times(entity.critDamage);
+            damage = damage.times(getEffectiveCritMultiplier(entity.critDamage, target.tenacity));
             queueCombatEvent({
                 sourceId: entity.id,
                 targetId: target.id,
@@ -710,9 +758,13 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
 
         let finalDamage = damage;
         if (action.damageElement === "physical") {
-            finalDamage = applyPhysicalMitigation(damage, target.armor);
+            finalDamage = applyPhysicalMitigation(damage, target.armor, entity.armorPenetration);
         } else {
-            finalDamage = damage.times(1 - target.resistances[action.damageElement]);
+            finalDamage = applyElementalMitigation(
+                damage,
+                target.resistances[action.damageElement],
+                entity.elementalPenetration,
+            );
         }
 
         let damageSuffix = "";

--- a/src/game/entity.test.ts
+++ b/src/game/entity.test.ts
@@ -42,12 +42,15 @@ describe("entity model", () => {
         expect(upgraded.armor.gt(baseline.armor)).toBe(true);
     });
 
-    it("derives accuracy, evasion, and parry ratings from existing attributes", () => {
+    it("derives combat ratings, penetration, and tenacity from existing attributes", () => {
         const warrior = createHero("hero_1", "Brom", "Warrior");
 
         expect(warrior.accuracyRating).toBeCloseTo(60.5);
         expect(warrior.evasionRating).toBeCloseTo(43);
         expect(warrior.parryRating).toBeCloseTo(18.75);
+        expect(warrior.armorPenetration).toBeCloseTo(12.5);
+        expect(warrior.elementalPenetration).toBeCloseTo(4.5);
+        expect(warrior.tenacity).toBeCloseTo(10.5);
     });
 
     it("creates tougher boss enemies on every tenth floor with the softened boss multipliers", () => {

--- a/src/game/entity.ts
+++ b/src/game/entity.ts
@@ -70,6 +70,9 @@ export interface Entity {
     accuracyRating: number;
     evasionRating: number;
     parryRating: number;
+    armorPenetration: number;
+    elementalPenetration: number;
+    tenacity: number;
 
     resistances: Elements;
 
@@ -237,6 +240,12 @@ export const STAT_MULTS = {
     EVASION_PER_WIS: 1,
     PARRY_PER_STR: 1.75,
     PARRY_PER_DEX: 0.25,
+    ARMOR_PEN_PER_STR: 1,
+    ARMOR_PEN_PER_DEX: 0.5,
+    ELEMENTAL_PEN_PER_INT: 1,
+    ELEMENTAL_PEN_PER_WIS: 0.5,
+    TENACITY_PER_VIT: 0.75,
+    TENACITY_PER_WIS: 1,
 };
 
 // Start Stats Helpers
@@ -289,6 +298,9 @@ export const calculateDerivedStats = (entity: Entity, prestigeUpgrades?: Prestig
     entity.accuracyRating = 50 + (attrs.dex * STAT_MULTS.ACCURACY_PER_DEX) + (attrs.int * STAT_MULTS.ACCURACY_PER_INT);
     entity.evasionRating = 35 + (attrs.dex * STAT_MULTS.EVASION_PER_DEX) + (attrs.wis * STAT_MULTS.EVASION_PER_WIS);
     entity.parryRating = (attrs.str * STAT_MULTS.PARRY_PER_STR) + (attrs.dex * STAT_MULTS.PARRY_PER_DEX);
+    entity.armorPenetration = (attrs.str * STAT_MULTS.ARMOR_PEN_PER_STR) + (attrs.dex * STAT_MULTS.ARMOR_PEN_PER_DEX);
+    entity.elementalPenetration = (attrs.int * STAT_MULTS.ELEMENTAL_PEN_PER_INT) + (attrs.wis * STAT_MULTS.ELEMENTAL_PEN_PER_WIS);
+    entity.tenacity = (attrs.vit * STAT_MULTS.TENACITY_PER_VIT) + (attrs.wis * STAT_MULTS.TENACITY_PER_WIS);
 
     // Resists
     const resistVal = Math.min(attrs.wis * STAT_MULTS.RESIST_PER_WIS, 0.75); // Cap at 75%
@@ -350,6 +362,7 @@ export const createHero = (
         armor: new Decimal(0), physicalDamage: new Decimal(0), magicDamage: new Decimal(0),
         critChance: 0.05, critDamage: 1.5,
         accuracyRating: 0, evasionRating: 0, parryRating: 0,
+        armorPenetration: 0, elementalPenetration: 0, tenacity: 0,
         resistances: { fire: 0, water: 0, earth: 0, air: 0, light: 0, shadow: 0 },
         actionProgress: 0,
         activeSkill: null,
@@ -459,6 +472,7 @@ export const createEnemy = (level: number, id: string, options: CreateEnemyOptio
         armor: new Decimal(0), physicalDamage: new Decimal(0), magicDamage: new Decimal(0),
         critChance: 0.05, critDamage: 1.5,
         accuracyRating: 0, evasionRating: 0, parryRating: 0,
+        armorPenetration: 0, elementalPenetration: 0, tenacity: 0,
         resistances: { fire: 0, water: 0, earth: 0, air: 0, light: 0, shadow: 0 },
         actionProgress: 0,
         activeSkill: null,

--- a/src/game/store/persistence.test.ts
+++ b/src/game/store/persistence.test.ts
@@ -51,7 +51,7 @@ describe("game-state persistence", () => {
         expect(restoredState.combatEvents).toEqual([]);
     });
 
-    it("rehydrates missing combat ratings from older save payloads", () => {
+    it("rehydrates missing combat ratings and scaling stats from older save payloads", () => {
         const exportedState = createInitialGameState({
             party: createStarterParty("Selene", "Cleric"),
             enemies: [createEnemy(3, "enemy_3")],
@@ -67,10 +67,16 @@ describe("game-state persistence", () => {
         delete payload.state.party[0]?.accuracyRating;
         delete payload.state.party[0]?.evasionRating;
         delete payload.state.party[0]?.parryRating;
+        delete payload.state.party[0]?.armorPenetration;
+        delete payload.state.party[0]?.elementalPenetration;
+        delete payload.state.party[0]?.tenacity;
         delete payload.state.party[0]?.guardStacks;
         delete payload.state.enemies[0]?.accuracyRating;
         delete payload.state.enemies[0]?.evasionRating;
         delete payload.state.enemies[0]?.parryRating;
+        delete payload.state.enemies[0]?.armorPenetration;
+        delete payload.state.enemies[0]?.elementalPenetration;
+        delete payload.state.enemies[0]?.tenacity;
         delete payload.state.enemies[0]?.enemyArchetype;
         delete payload.state.enemies[0]?.enemyElement;
         delete payload.state.enemies[0]?.guardStacks;
@@ -80,10 +86,16 @@ describe("game-state persistence", () => {
         expect(restoredState.party[0]?.accuracyRating).toBeGreaterThan(0);
         expect(restoredState.party[0]?.evasionRating).toBeGreaterThan(0);
         expect(restoredState.party[0]?.parryRating).toBeGreaterThan(0);
+        expect(restoredState.party[0]?.armorPenetration).toBeGreaterThan(0);
+        expect(restoredState.party[0]?.elementalPenetration).toBeGreaterThan(0);
+        expect(restoredState.party[0]?.tenacity).toBeGreaterThan(0);
         expect(restoredState.party[0]?.guardStacks).toBe(0);
         expect(restoredState.enemies[0]?.accuracyRating).toBeGreaterThan(0);
         expect(restoredState.enemies[0]?.evasionRating).toBeGreaterThan(0);
         expect(restoredState.enemies[0]?.parryRating).toBeGreaterThan(0);
+        expect(restoredState.enemies[0]?.armorPenetration).toBeGreaterThan(0);
+        expect(restoredState.enemies[0]?.elementalPenetration).toBeGreaterThan(0);
+        expect(restoredState.enemies[0]?.tenacity).toBeGreaterThan(0);
         expect(restoredState.enemies[0]?.enemyArchetype).toBe("Bruiser");
         expect(restoredState.enemies[0]?.guardStacks).toBe(0);
     });


### PR DESCRIPTION
## Summary
- add bounded `armorPenetration`, `elementalPenetration`, and `tenacity` as derived combat stats
- apply penetration to physical and elemental mitigation while keeping both systems capped and testable
- apply tenacity to incoming crit bonus damage only, reserving it as the future status-resistance hook
- surface the new stats in the entity tooltip and update the architecture docs
- keep save imports backward-compatible by recalculating missing derived combat ratings on hydrate

## Testing
- npm test
- npm run build

Closes #45