### PR TITLE
[codex] refactor: data-drive hero class templates for issue #69

### DIFF
--- a/docs/ARCHITECTURE/README.md
+++ b/docs/ARCHITECTURE/README.md
@@ -20,6 +20,7 @@ We use a format inspired by Architecture Decision Records (ADRs) to document sig
 - [005 - Expandable Party System](gamedecisions/005-expandable-party-system.md)
 - [006 - Hero Retirement and Prestige Mechanics](gamedecisions/006-hero-retirement-and-prestige.md)
 - [007 - Layered Combat Model](gamedecisions/007-layered-combat-model.md)
+- [008 - Hero Class Templates, Growth Packages, and Resource Models](gamedecisions/008-hero-class-templates.md)
 
 ### Technical Decisions
 

--- a/docs/ARCHITECTURE/gamedecisions/002-attributes-and-stats.md
+++ b/docs/ARCHITECTURE/gamedecisions/002-attributes-and-stats.md
@@ -94,7 +94,7 @@ Classes still use class-specific secondary resources:
 * **Cleric (Mana):** maximum `50 + (INT * 5)`; starts full; regenerates `WIS * 0.5` per action tick
 * **Archer (Cunning):** maximum `50 + (INT * 5)`; starts full; regenerates `0.75` per action tick
 
-These are still acceptable as attribute-facing baselines. The layered model does not require replacing them before the class-template work in `#69`.
+These are still acceptable as attribute-facing baselines. The layered model does not require replacing them before the template-driven class identity defined in [008 - Hero Class Templates, Growth Packages, and Resource Models](008-hero-class-templates.md).
 
 ### Current Hard Caps and Bounds
 

--- a/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
+++ b/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
@@ -34,7 +34,7 @@ When an EXP threshold is reached, the hero levels up, deducting the required amo
 * **Cleric:** +2 INT, +2 WIS, +1 STR, +1 VIT, +1 DEX
 * **Archer:** +2 DEX, +1 STR, +1 VIT, +1 INT, +1 WIS
 
-These growth packages remain the live runtime baseline. Follow-up issue `#69` will define the explicit class-template source of truth that owns these growth patterns more cleanly.
+These growth packages remain the live runtime baseline, but the source of truth for them now lives in [008 - Hero Class Templates, Growth Packages, and Resource Models](008-hero-class-templates.md).
 
 ### Layered Progression Sources
 
@@ -107,4 +107,4 @@ Because future differentiation layers will introduce new progression fields, add
 
 * **Easier:** Auto-allocation of attributes still prevents idle-flow interruption, while the new layered rule creates a cleaner place for later build differentiation systems to live.
 * **Easier:** The wipe loop, slot unlocks, and prestige systems can keep functioning while later issues add template, talent, and equipment layers on top.
-* **Difficult:** Because the runtime still uses attribute-heavy derived stat math today, the mathematical wall remains sensitive until `#69` and `#70` redistribute more identity into templates and layered ratings.
+* **Difficult:** Because the runtime still uses attribute-heavy derived stat math today, the mathematical wall remains sensitive until `#70` redistributes more identity into layered ratings on top of the now-centralized class templates.

--- a/docs/ARCHITECTURE/gamedecisions/007-layered-combat-model.md
+++ b/docs/ARCHITECTURE/gamedecisions/007-layered-combat-model.md
@@ -87,7 +87,7 @@ The current runtime still derives many combat outputs directly from `VIT`, `STR`
 This decision intentionally sets boundaries for the rest of the foundation work:
 
 * **`#68`** defines the accepted model, names, ownership, and bounded formula direction
-* **`#69`** defines class-template data modeling for base stats, growth, resources, and action packages
+* **`#69`** defines class-template data modeling for base stats, growth, resources, and action packages, implemented in [008 - Hero Class Templates, Growth Packages, and Resource Models](008-hero-class-templates.md)
 * **`#70`** refactors runtime derived stat sourcing and tunes coefficient-level formulas against the accepted model
 * **`#71`** adds explicit versioned save migrations so new progression/combat fields remain backward-compatible
 

--- a/docs/ARCHITECTURE/gamedecisions/008-hero-class-templates.md
+++ b/docs/ARCHITECTURE/gamedecisions/008-hero-class-templates.md
@@ -1,0 +1,66 @@
+# 008 - Hero Class Templates, Growth Packages, and Resource Models
+
+**Date:** 2026-03-15
+**Status:** Accepted
+
+## Context
+
+[007 - Layered Combat Model](007-layered-combat-model.md) established that class templates should answer how a character fights. Before this change, current hero identity was still split across multiple code branches:
+
+* base attributes in hero construction
+* level-up growth in combat reward logic
+* resource setup in hero creation, wipe recovery, and per-tick updates
+* combat action selection in simulation branches
+
+That made current classes harder to reason about and left future classes with no single source of truth.
+
+## Decision
+
+Hero classes are now defined through explicit class templates. Each template owns:
+
+* display metadata
+* base attributes
+* level-up growth package
+* resource model
+* baseline combat package
+* current action-package identifier and passive hooks
+
+The first implementation covers the shipped hero classes: `Warrior`, `Cleric`, and `Archer`.
+
+### Template Shape
+
+Each hero template includes:
+
+* **Base attributes:** the level-1 starting identity package
+* **Growth package:** the attribute increments applied on each level-up
+* **Resource model:** resource type, starting state, maximum-resource formula inputs, per-tick regeneration, and any resource triggers such as on-hit or on-attack gains
+* **Combat profile:** current basic-action identity, crit multiplier, physical damage source attribute, and baseline combat-rating tendencies
+* **Action package:** the current package id plus the data needed for the package's shipped special actions or support actions
+
+### Current Hero Packages
+
+* **Warrior:** STR/VIT-heavy bruiser package with Rage-based burst and resource gains tied to combat participation
+* **Cleric:** INT/WIS-heavy support package with Mana regeneration, triage healing, Bless/Regen support, and Light spell pressure
+* **Archer:** DEX-heavy ranged package with fast Cunning regeneration and crit-oriented burst shots
+
+### Scope Boundaries
+
+This change does not make every future class completely declarative. Current class templates centralize identity and route the existing simulation through package ids, but additional action-package logic may still be added when a genuinely new class behavior is introduced.
+
+That tradeoff is intentional for the first pass:
+
+* adding another class with an existing package shape should mostly be data definition
+* adding a truly new package shape may still require new simulation logic
+
+### Relationship to Follow-up Work
+
+This decision is the implementation follow-through for issue `#69`.
+
+* `#69` centralizes current class identity into explicit templates
+* `#70` will use those templates as one of the layered stat sources when combat ratings stop being mostly raw attribute products
+
+## Consequences
+
+* **Easier:** Current hero identity now has a single source of truth, which reduces drift between creation, leveling, resource behavior, and combat actions.
+* **Easier:** Future classes can reuse the same template structure instead of duplicating hardcoded branches across unrelated systems.
+* **Difficult:** The first pass still uses package-id-driven combat logic rather than a fully declarative skill engine, so template data and simulation behavior must stay aligned as new packages are introduced.

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { HERO_CLASSES, getHeroClassTemplate } from '../game/classTemplates';
 import type { HeroClass } from '../game/entity';
 import { createStarterParty } from '../game/entity';
 import { useGameStore } from '../game/store/gameStore';
@@ -36,42 +37,25 @@ export const CharacterCreation: React.FC = () => {
                     </div>
 
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                        <Button
-                            variant="hero-card"
-                            className="h-auto flex-col items-center gap-3 p-4"
-                            aria-pressed={selectedClass === 'Warrior'}
-                            onClick={() => setSelectedClass('Warrior')}
-                        >
-                            <img src={`${import.meta.env.BASE_URL}assets/hero_warrior.png`} alt="Warrior" className="w-20 h-20 object-contain drop-shadow-md" />
-                            <div className="text-center">
-                                <h3 className="font-bold text-slate-50 text-lg mb-1">Warrior</h3>
-                                <p className="text-slate-400 text-xs whitespace-normal lead-tight">High HP, builds Rage into crushing weapon skills.</p>
-                            </div>
-                        </Button>
-                        <Button
-                            variant="hero-card"
-                            className="h-auto flex-col items-center gap-3 p-4"
-                            aria-pressed={selectedClass === 'Cleric'}
-                            onClick={() => setSelectedClass('Cleric')}
-                        >
-                            <img src={`${import.meta.env.BASE_URL}assets/hero_cleric.png`} alt="Cleric" className="w-20 h-20 object-contain drop-shadow-md" />
-                            <div className="text-center">
-                                <h3 className="font-bold text-slate-50 text-lg mb-1">Cleric</h3>
-                                <p className="text-slate-400 text-xs whitespace-normal lead-tight">Uses Mana to smite enemies and heal injured allies.</p>
-                            </div>
-                        </Button>
-                        <Button
-                            variant="hero-card"
-                            className="h-auto flex-col items-center gap-3 p-4"
-                            aria-pressed={selectedClass === 'Archer'}
-                            onClick={() => setSelectedClass('Archer')}
-                        >
-                            <img src={`${import.meta.env.BASE_URL}assets/hero_archer.png`} alt="Archer" className="w-20 h-20 object-contain drop-shadow-md" />
-                            <div className="text-center">
-                                <h3 className="font-bold text-slate-50 text-lg mb-1">Archer</h3>
-                                <p className="text-slate-400 text-xs whitespace-normal lead-tight">Uses Cunning for precision shots and lethal crits.</p>
-                            </div>
-                        </Button>
+                        {HERO_CLASSES.map((heroClass) => {
+                            const template = getHeroClassTemplate(heroClass);
+
+                            return (
+                                <Button
+                                    key={heroClass}
+                                    variant="hero-card"
+                                    className="h-auto flex-col items-center gap-3 p-4"
+                                    aria-pressed={selectedClass === heroClass}
+                                    onClick={() => setSelectedClass(heroClass)}
+                                >
+                                    <img src={`${import.meta.env.BASE_URL}${template.imageAsset}`} alt={template.displayName} className="w-20 h-20 object-contain drop-shadow-md" />
+                                    <div className="text-center">
+                                        <h3 className="font-bold text-slate-50 text-lg mb-1">{template.displayName}</h3>
+                                        <p className="text-slate-400 text-xs whitespace-normal lead-tight">{template.description}</p>
+                                    </div>
+                                </Button>
+                            );
+                        })}
                     </div>
 
                     <p className="text-center text-xs text-slate-400">

--- a/src/components/EntityRoster.tsx
+++ b/src/components/EntityRoster.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Skull } from 'lucide-react';
 
+import { getHeroClassTemplate } from '../game/classTemplates';
 import { getEnemyArchetypeLabel, getStatusEffectBadge, getStatusEffectName } from '../game/entity';
 import type { Entity, StatusEffect } from '../game/entity';
 import type { CombatEvent } from '../game/store/types';
@@ -39,9 +40,7 @@ const hpColorFor = (entity: Entity) => {
 };
 
 const resourceColorFor = (entity: Entity) => {
-  if (entity.class === 'Warrior') return 'bg-red-500';
-  if (entity.class === 'Cleric') return 'bg-blue-500';
-  if (entity.class === 'Archer') return 'bg-yellow-500';
+  if (!entity.isEnemy) return getHeroClassTemplate(entity.class).resourceModel.barColorClass;
   return 'bg-purple-500';
 };
 

--- a/src/game/classTemplates.ts
+++ b/src/game/classTemplates.ts
@@ -1,0 +1,242 @@
+import type { Attributes, DamageElement, EntityClass, HeroClass } from "./entity";
+
+export type HeroCombatRating =
+    | "power"
+    | "spellPower"
+    | "precision"
+    | "haste"
+    | "guard"
+    | "resolve"
+    | "potency"
+    | "crit";
+
+export type HeroActionPackageId = "warrior" | "cleric" | "archer";
+export type ResourceRegenKind = "none" | "flat" | "attribute";
+export type CombatDamageStat = "physicalDamage" | "magicDamage";
+export type CombatDeliveryType = "melee" | "ranged" | "spell";
+
+export interface HeroResourceModel {
+    id: "rage" | "mana" | "cunning";
+    displayName: string;
+    barColorClass: string;
+    startsFull: boolean;
+    maxBase: number;
+    maxPerInt: number;
+    regenKind: ResourceRegenKind;
+    regenFlat: number;
+    regenAttribute?: keyof Attributes;
+    regenAttributeMultiplier?: number;
+    gainOnResolvedAttack: number;
+    gainOnTakeDamage: number;
+}
+
+export interface HeroBasicActionDefinition {
+    name: string;
+    damageStat: CombatDamageStat;
+    damageElement: DamageElement;
+    deliveryType: CombatDeliveryType;
+    canParry: boolean;
+}
+
+export interface HeroSpecialAttackDefinition {
+    name: string;
+    cost: number;
+    damageMultiplier: number;
+    critChanceBonus?: number;
+    canParry: boolean;
+}
+
+export interface HeroHealSupportDefinition {
+    name: string;
+    cost: number;
+    hpThreshold: number;
+    healMultiplier: number;
+}
+
+export interface HeroBlessSupportDefinition {
+    name: string;
+    cost: number;
+    regenMultiplier: number;
+}
+
+export interface HeroActionPackageDefinition {
+    id: HeroActionPackageId;
+    passiveHooks: string[];
+    specialAttack?: HeroSpecialAttackDefinition;
+    heal?: HeroHealSupportDefinition;
+    bless?: HeroBlessSupportDefinition;
+}
+
+export interface HeroCombatProfile {
+    physicalDamageSourceAttribute: "str" | "dex";
+    physicalDamageSourceMultiplier: number;
+    critMultiplier: number;
+    basicAction: HeroBasicActionDefinition;
+    baselineRatings: HeroCombatRating[];
+}
+
+export interface HeroClassTemplate {
+    id: HeroClass;
+    displayName: string;
+    description: string;
+    imageAsset: string;
+    namePool: string[];
+    baseAttributes: Attributes;
+    growth: Attributes;
+    resourceModel: HeroResourceModel;
+    combatProfile: HeroCombatProfile;
+    actionPackage: HeroActionPackageDefinition;
+}
+
+export const HERO_CLASS_TEMPLATES: Record<HeroClass, HeroClassTemplate> = {
+    Warrior: {
+        id: "Warrior",
+        displayName: "Warrior",
+        description: "High HP, builds Rage into crushing weapon skills.",
+        imageAsset: "assets/hero_warrior.png",
+        namePool: ["Brom", "Tarin", "Mira", "Hale", "Sable"],
+        baseAttributes: { vit: 10, str: 10, dex: 5, int: 3, wis: 3 },
+        growth: { vit: 2, str: 2, dex: 1, int: 1, wis: 1 },
+        resourceModel: {
+            id: "rage",
+            displayName: "Rage",
+            barColorClass: "bg-red-500",
+            startsFull: false,
+            maxBase: 100,
+            maxPerInt: 0,
+            regenKind: "none",
+            regenFlat: 0,
+            gainOnResolvedAttack: 8,
+            gainOnTakeDamage: 5,
+        },
+        combatProfile: {
+            physicalDamageSourceAttribute: "str",
+            physicalDamageSourceMultiplier: 1.5,
+            critMultiplier: 1.5,
+            basicAction: {
+                name: "Attack",
+                damageStat: "physicalDamage",
+                damageElement: "physical",
+                deliveryType: "melee",
+                canParry: true,
+            },
+            baselineRatings: ["guard", "power"],
+        },
+        actionPackage: {
+            id: "warrior",
+            passiveHooks: ["resource-on-resolved-attack", "resource-on-take-damage"],
+            specialAttack: {
+                name: "Rage Strike",
+                cost: 40,
+                damageMultiplier: 2,
+                canParry: false,
+            },
+        },
+    },
+    Cleric: {
+        id: "Cleric",
+        displayName: "Cleric",
+        description: "Uses Mana to smite enemies and heal injured allies.",
+        imageAsset: "assets/hero_cleric.png",
+        namePool: ["Lyra", "Seren", "Ione", "Thess", "Aster"],
+        baseAttributes: { vit: 7, str: 4, dex: 4, int: 8, wis: 10 },
+        growth: { vit: 1, str: 1, dex: 1, int: 2, wis: 2 },
+        resourceModel: {
+            id: "mana",
+            displayName: "Mana",
+            barColorClass: "bg-blue-500",
+            startsFull: true,
+            maxBase: 50,
+            maxPerInt: 5,
+            regenKind: "attribute",
+            regenFlat: 0,
+            regenAttribute: "wis",
+            regenAttributeMultiplier: 0.5,
+            gainOnResolvedAttack: 0,
+            gainOnTakeDamage: 0,
+        },
+        combatProfile: {
+            physicalDamageSourceAttribute: "str",
+            physicalDamageSourceMultiplier: 1.5,
+            critMultiplier: 1.5,
+            basicAction: {
+                name: "Smite",
+                damageStat: "magicDamage",
+                damageElement: "light",
+                deliveryType: "spell",
+                canParry: false,
+            },
+            baselineRatings: ["spellPower", "resolve"],
+        },
+        actionPackage: {
+            id: "cleric",
+            passiveHooks: ["support-priority", "cleanse-on-bless"],
+            heal: {
+                name: "Mend",
+                cost: 35,
+                hpThreshold: 0.65,
+                healMultiplier: 1.75,
+            },
+            bless: {
+                name: "Bless",
+                cost: 25,
+                regenMultiplier: 0.15,
+            },
+        },
+    },
+    Archer: {
+        id: "Archer",
+        displayName: "Archer",
+        description: "Uses Cunning for precision shots and lethal crits.",
+        imageAsset: "assets/hero_archer.png",
+        namePool: ["Kestrel", "Nyx", "Corin", "Vera", "Pike"],
+        baseAttributes: { vit: 6, str: 5, dex: 12, int: 4, wis: 4 },
+        growth: { vit: 1, str: 1, dex: 2, int: 1, wis: 1 },
+        resourceModel: {
+            id: "cunning",
+            displayName: "Cunning",
+            barColorClass: "bg-yellow-500",
+            startsFull: true,
+            maxBase: 50,
+            maxPerInt: 5,
+            regenKind: "flat",
+            regenFlat: 0.75,
+            gainOnResolvedAttack: 0,
+            gainOnTakeDamage: 0,
+        },
+        combatProfile: {
+            physicalDamageSourceAttribute: "dex",
+            physicalDamageSourceMultiplier: 1.5,
+            critMultiplier: 2,
+            basicAction: {
+                name: "Attack",
+                damageStat: "physicalDamage",
+                damageElement: "physical",
+                deliveryType: "ranged",
+                canParry: false,
+            },
+            baselineRatings: ["precision", "haste", "crit"],
+        },
+        actionPackage: {
+            id: "archer",
+            passiveHooks: ["precision-burst"],
+            specialAttack: {
+                name: "Piercing Shot",
+                cost: 35,
+                damageMultiplier: 1.6,
+                critChanceBonus: 0.15,
+                canParry: false,
+            },
+        },
+    },
+};
+
+export const HERO_CLASSES: HeroClass[] = ["Warrior", "Cleric", "Archer"];
+
+export const getHeroClassTemplate = (heroClass: HeroClass | EntityClass): HeroClassTemplate => {
+    if (heroClass === "Monster") {
+        throw new Error("Monster does not have a hero class template.");
+    }
+
+    return HERO_CLASS_TEMPLATES[heroClass];
+};

--- a/src/game/engine/simulation.test.ts
+++ b/src/game/engine/simulation.test.ts
@@ -81,6 +81,37 @@ describe("simulation engine", () => {
         expect(lateEncounter.map((enemy) => enemy.enemyArchetype)).toEqual(["Caster", "Bruiser", "Support"]);
     });
 
+    it("applies class-template growth packages when heroes level up from combat rewards", () => {
+        const warrior = createHero("hero_1", "Brom", "Warrior");
+        warrior.exp = warrior.expToNext.minus(1);
+        warrior.actionProgress = 100;
+        warrior.critChance = 0;
+
+        const enemy = createEnemy(1, "enemy_1");
+        enemy.currentHp = new Decimal(1);
+        enemy.actionProgress = -999;
+
+        const result = simulateTick(
+            createInitialGameState({
+                party: [warrior],
+                enemies: [enemy],
+                combatLog: [],
+            }),
+            createSequenceRandomSource(0, 0, 0.99, 0.99),
+        );
+
+        const leveledWarrior = result.state.party[0];
+        expect(leveledWarrior.level).toBe(2);
+        expect(leveledWarrior.attributes).toMatchObject({
+            vit: 12,
+            str: 12,
+            dex: 6,
+            int: 4,
+            wis: 4,
+        });
+        expect(result.state.combatLog.some((entry) => /reached level 2/i.test(entry))).toBe(true);
+    });
+
     it("applies light resistance to cleric smite damage", () => {
         const cleric = createHero("hero_1", "Ayla", "Cleric");
         cleric.actionProgress = 99;

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js";
 
+import { getHeroClassTemplate } from "../classTemplates";
 import {
     BASE_META_UPGRADES,
     createEnemy,
@@ -7,6 +8,7 @@ import {
     getEnemyElementForEncounter,
     getExpRequirement,
     getStatusEffectName,
+    isHeroClass,
     inferEnemyArchetype,
     recalculateEntity,
 } from "../entity";
@@ -18,12 +20,12 @@ export const GAME_TICK_RATE = 20;
 export const GAME_TICK_MS = 1000 / GAME_TICK_RATE;
 export const ATB_RATE = 2;
 export const DEX_ATB_RATE = 0.06;
-export const WARRIOR_RAGE_STRIKE_COST = 40;
-export const WARRIOR_RAGE_PER_ATTACK = 8;
-export const WARRIOR_RAGE_WHEN_HIT = 5;
-export const ARCHER_PIERCING_SHOT_COST = 35;
-export const ARCHER_PIERCING_SHOT_CRIT_BONUS = 0.15;
-export const ARCHER_CUNNING_REGEN_PER_TICK = 0.75;
+export const WARRIOR_RAGE_STRIKE_COST = getHeroClassTemplate("Warrior").actionPackage.specialAttack?.cost ?? 40;
+export const WARRIOR_RAGE_PER_ATTACK = getHeroClassTemplate("Warrior").resourceModel.gainOnResolvedAttack;
+export const WARRIOR_RAGE_WHEN_HIT = getHeroClassTemplate("Warrior").resourceModel.gainOnTakeDamage;
+export const ARCHER_PIERCING_SHOT_COST = getHeroClassTemplate("Archer").actionPackage.specialAttack?.cost ?? 35;
+export const ARCHER_PIERCING_SHOT_CRIT_BONUS = getHeroClassTemplate("Archer").actionPackage.specialAttack?.critChanceBonus ?? 0.15;
+export const ARCHER_CUNNING_REGEN_PER_TICK = getHeroClassTemplate("Archer").resourceModel.regenFlat;
 export const ARMOR_MITIGATION_SCALE = 2;
 export const MAX_PENETRATION_REDUCTION = 0.6;
 export const PENETRATION_SOFTCAP = 60;
@@ -50,7 +52,7 @@ export const HEX_HEALING_REDUCTION = 0.3;
 export const BLIND_BASE_CHANCE = 0.35;
 export const BLIND_DURATION_TICKS = GAME_TICK_RATE * 3;
 export const BLIND_ACCURACY_REDUCTION = 15;
-export const CLERIC_BLESS_COST = 25;
+export const CLERIC_BLESS_COST = getHeroClassTemplate("Cleric").actionPackage.bless?.cost ?? 25;
 
 const SKILL_BANNER_TICKS = GAME_TICK_RATE;
 const COMBAT_EVENT_TICKS = Math.round(GAME_TICK_RATE * 1.4);
@@ -273,8 +275,9 @@ export const getFloorReplayState = (state: GameState): Partial<GameState> => ({
 export const getPartyWipeState = (state: GameState): Partial<GameState> => {
     const healedParty = state.party.map((hero) => {
         const refreshed = recalculateEntity(cloneEntity(hero), state.metaUpgrades, state.prestigeUpgrades);
+        const heroTemplate = getHeroClassTemplate(hero.class);
         refreshed.currentHp = refreshed.maxHp;
-        refreshed.currentResource = hero.class === "Warrior" ? new Decimal(0) : refreshed.maxResource;
+        refreshed.currentResource = heroTemplate.resourceModel.startsFull ? refreshed.maxResource : new Decimal(0);
         refreshed.guardStacks = 0;
         refreshed.statusEffects = [];
         refreshed.activeSkill = null;
@@ -291,6 +294,14 @@ export const getPartyWipeState = (state: GameState): Partial<GameState> => {
         combatLog: prependCombatMessages(state.combatLog, "The party was wiped out! Resetting to Floor 1..."),
         combatEvents: [],
     };
+};
+
+const getHeroTemplateForEntity = (entity: Entity) => {
+    if (entity.isEnemy || !isHeroClass(entity.class)) {
+        return null;
+    }
+
+    return getHeroClassTemplate(entity.class);
 };
 
 const clampChance = (min: number, max: number, value: number) => Math.max(min, Math.min(max, value));
@@ -661,49 +672,48 @@ const getDamageAction = (entity: Entity): DamageAction => {
         return getEnemyDamageAction(entity, inferEnemyArchetype(entity) ?? "Bruiser");
     }
 
+    const heroTemplate = getHeroClassTemplate(entity.class);
+    const basicAction = heroTemplate.combatProfile.basicAction;
     let action: DamageAction = {
-        name: "Attack",
-        damage: entity.physicalDamage,
-        damageElement: "physical",
-        deliveryType: entity.class === "Archer" ? "ranged" : "melee",
+        name: basicAction.name,
+        damage: basicAction.damageStat === "magicDamage" ? entity.magicDamage : entity.physicalDamage,
+        damageElement: basicAction.damageElement,
+        deliveryType: basicAction.deliveryType,
         critChance: entity.critChance,
         canDodge: true,
-        canParry: entity.class !== "Archer",
+        canParry: basicAction.canParry,
     };
 
-    if (entity.class === "Cleric") {
-        action = {
-            name: "Smite",
-            damage: entity.magicDamage,
-            damageElement: "light",
-            deliveryType: "spell",
-            critChance: entity.critChance,
-            canDodge: true,
-            canParry: false,
-        };
-    }
-
-    if (!entity.isEnemy && entity.class === "Warrior" && entity.currentResource.gte(WARRIOR_RAGE_STRIKE_COST)) {
-        entity.currentResource = entity.currentResource.minus(WARRIOR_RAGE_STRIKE_COST);
-        action = {
-            ...action,
-            name: "Rage Strike",
-            damage: entity.physicalDamage.times(2),
-            damageElement: "physical",
-            deliveryType: "melee",
-            canParry: false,
-        };
-    } else if (!entity.isEnemy && entity.class === "Archer" && entity.currentResource.gte(ARCHER_PIERCING_SHOT_COST)) {
-        entity.currentResource = entity.currentResource.minus(ARCHER_PIERCING_SHOT_COST);
-        action = {
-            ...action,
-            name: "Piercing Shot",
-            damage: entity.physicalDamage.times(1.6),
-            damageElement: "physical",
-            deliveryType: "ranged",
-            critChance: Math.min(1, entity.critChance + ARCHER_PIERCING_SHOT_CRIT_BONUS),
-            canParry: false,
-        };
+    switch (heroTemplate.actionPackage.id) {
+        case "warrior": {
+            const specialAttack = heroTemplate.actionPackage.specialAttack;
+            if (specialAttack && entity.currentResource.gte(specialAttack.cost)) {
+                entity.currentResource = entity.currentResource.minus(specialAttack.cost);
+                action = {
+                    ...action,
+                    name: specialAttack.name,
+                    damage: entity.physicalDamage.times(specialAttack.damageMultiplier),
+                    canParry: specialAttack.canParry,
+                };
+            }
+            break;
+        }
+        case "archer": {
+            const specialAttack = heroTemplate.actionPackage.specialAttack;
+            if (specialAttack && entity.currentResource.gte(specialAttack.cost)) {
+                entity.currentResource = entity.currentResource.minus(specialAttack.cost);
+                action = {
+                    ...action,
+                    name: specialAttack.name,
+                    damage: entity.physicalDamage.times(specialAttack.damageMultiplier),
+                    critChance: Math.min(1, entity.critChance + (specialAttack.critChanceBonus ?? 0)),
+                    canParry: specialAttack.canParry,
+                };
+            }
+            break;
+        }
+        default:
+            break;
     }
 
     if (action.deliveryType === "ranged" && action.damageElement === "physical") {
@@ -713,12 +723,22 @@ const getDamageAction = (entity: Entity): DamageAction => {
     return action;
 };
 
-const grantWarriorAttackRage = (entity: Entity) => {
-    if (entity.class !== "Warrior") {
+const grantResolvedAttackResource = (entity: Entity) => {
+    const heroTemplate = getHeroTemplateForEntity(entity);
+    if (!heroTemplate || heroTemplate.resourceModel.gainOnResolvedAttack <= 0) {
         return;
     }
 
-    entity.currentResource = Decimal.min(entity.maxResource, entity.currentResource.plus(WARRIOR_RAGE_PER_ATTACK));
+    entity.currentResource = Decimal.min(entity.maxResource, entity.currentResource.plus(heroTemplate.resourceModel.gainOnResolvedAttack));
+};
+
+const grantTakeDamageResource = (entity: Entity) => {
+    const heroTemplate = getHeroTemplateForEntity(entity);
+    if (!heroTemplate || heroTemplate.resourceModel.gainOnTakeDamage <= 0) {
+        return;
+    }
+
+    entity.currentResource = Decimal.min(entity.maxResource, entity.currentResource.plus(heroTemplate.resourceModel.gainOnTakeDamage));
 };
 
 export const simulateTick = (state: GameState, randomSource: SimulationRandomSource = defaultRandomSource): SimulationResult => {
@@ -887,26 +907,12 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
                 nextHero.exp = nextHero.exp.minus(nextHero.expToNext);
                 nextHero.level += 1;
                 nextHero.expToNext = getExpRequirement(nextHero.level);
-
-                if (nextHero.class === "Warrior") {
-                    nextHero.attributes.str += 2;
-                    nextHero.attributes.vit += 2;
-                    nextHero.attributes.dex += 1;
-                    nextHero.attributes.int += 1;
-                    nextHero.attributes.wis += 1;
-                } else if (nextHero.class === "Cleric") {
-                    nextHero.attributes.int += 2;
-                    nextHero.attributes.wis += 2;
-                    nextHero.attributes.str += 1;
-                    nextHero.attributes.vit += 1;
-                    nextHero.attributes.dex += 1;
-                } else if (nextHero.class === "Archer") {
-                    nextHero.attributes.dex += 2;
-                    nextHero.attributes.str += 1;
-                    nextHero.attributes.vit += 1;
-                    nextHero.attributes.int += 1;
-                    nextHero.attributes.wis += 1;
-                }
+                const heroTemplate = getHeroClassTemplate(nextHero.class);
+                nextHero.attributes.str += heroTemplate.growth.str;
+                nextHero.attributes.vit += heroTemplate.growth.vit;
+                nextHero.attributes.dex += heroTemplate.growth.dex;
+                nextHero.attributes.int += heroTemplate.growth.int;
+                nextHero.attributes.wis += heroTemplate.growth.wis;
 
                 nextHero = recalculateEntity(nextHero, draft.metaUpgrades, draft.prestigeUpgrades);
                 logMessages.push(`${nextHero.name} reached level ${nextHero.level}!`);
@@ -986,12 +992,21 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
 
         const hasteBonus = draft.prestigeUpgrades.gameSpeed * 0.1; // +10% speed up per level
         entity.actionProgress += (ATB_RATE + (entity.attributes.dex * DEX_ATB_RATE)) * (1 + hasteBonus) * getAtbMultiplier(entity);
+        const heroTemplate = getHeroTemplateForEntity(entity);
 
-        if (entity.class === "Cleric" || entity.class === "Archer") {
-            const regen = entity.class === "Cleric" ? entity.attributes.wis * 0.5 : ARCHER_CUNNING_REGEN_PER_TICK;
-            entity.currentResource = entity.currentResource.plus(regen);
-            if (entity.currentResource.gt(entity.maxResource)) {
-                entity.currentResource = entity.maxResource;
+        if (heroTemplate) {
+            let regen = 0;
+            if (heroTemplate.resourceModel.regenKind === "flat") {
+                regen = heroTemplate.resourceModel.regenFlat;
+            } else if (heroTemplate.resourceModel.regenKind === "attribute" && heroTemplate.resourceModel.regenAttribute) {
+                regen = entity.attributes[heroTemplate.resourceModel.regenAttribute] * (heroTemplate.resourceModel.regenAttributeMultiplier ?? 0);
+            }
+
+            if (regen > 0) {
+                entity.currentResource = entity.currentResource.plus(regen);
+                if (entity.currentResource.gt(entity.maxResource)) {
+                    entity.currentResource = entity.maxResource;
+                }
             }
         }
 
@@ -1004,15 +1019,15 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
 
         const livingAllies = allies.filter((ally) => ally.currentHp.gt(0));
 
-        if (!entity.isEnemy && entity.class === "Cleric") {
-            const healCost = new Decimal(35);
+        if (!entity.isEnemy && heroTemplate?.actionPackage.id === "cleric") {
+            const healDefinition = heroTemplate.actionPackage.heal;
             const healTarget = getLowestHpRatioTarget(livingAllies.filter((ally) => ally.currentHp.lt(ally.maxHp)));
 
-            if (healTarget && entity.currentResource.gte(healCost) && getHpRatio(healTarget) < 0.65) {
-                const rawHealAmount = entity.magicDamage.times(1.75);
+            if (healDefinition && healTarget && entity.currentResource.gte(healDefinition.cost) && getHpRatio(healTarget) < healDefinition.hpThreshold) {
+                const rawHealAmount = entity.magicDamage.times(healDefinition.healMultiplier);
                 const healAmount = rawHealAmount.times(getHealingMultiplier(healTarget));
-                setActiveSkill(entity, "Mend");
-                entity.currentResource = entity.currentResource.minus(healCost);
+                setActiveSkill(entity, healDefinition.name);
+                entity.currentResource = entity.currentResource.minus(healDefinition.cost);
                 healTarget.currentHp = Decimal.min(healTarget.maxHp, healTarget.currentHp.plus(healAmount));
                 queueCombatEvent({
                     sourceId: entity.id,
@@ -1026,12 +1041,12 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
                 return;
             }
 
-            const blessCost = new Decimal(CLERIC_BLESS_COST);
+            const blessDefinition = heroTemplate.actionPackage.bless;
             // Bless targets other party members only; solo Clerics fall through to Smite
             const blessTarget = livingAllies.find((ally) => ally.id !== entity.id && getCleanseableStatusEffect(ally))
                 ?? livingAllies.find((ally) => ally.id !== entity.id && !ally.statusEffects.some((se) => se.key === "regen"));
-            if (blessTarget && entity.currentResource.gte(blessCost)) {
-                const regenPotency = entity.magicDamage.times(REGEN_TICK_HEAL_MULTIPLIER).toNumber();
+            if (blessDefinition && blessTarget && entity.currentResource.gte(blessDefinition.cost)) {
+                const regenPotency = entity.magicDamage.times(blessDefinition.regenMultiplier).toNumber();
                 const regenEffect: StatusEffect = {
                     ...getStatusConfig("regen"),
                     sourceId: entity.id,
@@ -1045,8 +1060,8 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
                 } else {
                     blessTarget.statusEffects.push(regenEffect);
                 }
-                setActiveSkill(entity, "Bless");
-                entity.currentResource = entity.currentResource.minus(blessCost);
+                setActiveSkill(entity, blessDefinition.name);
+                entity.currentResource = entity.currentResource.minus(blessDefinition.cost);
                 queueStatusEvent(blessTarget, "regen", "apply", getStatusEffectName("regen"));
                 logMessages.push(`${entity.name} casts Bless on ${blessTarget.name}!`);
                 const cleansedStatus = getCleanseableStatusEffect(blessTarget);
@@ -1114,7 +1129,7 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
             : getPhysicalHitChance(entity, target);
 
         if (action.canDodge && randomSource.next() >= hitChance) {
-            grantWarriorAttackRage(entity);
+            grantResolvedAttackResource(entity);
             queueCombatEvent({
                 sourceId: entity.id,
                 targetId: target.id,
@@ -1127,7 +1142,7 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
         }
 
         if (action.canParry && action.deliveryType === "melee" && action.damageElement === "physical" && randomSource.next() < getParryChance(entity, target)) {
-            grantWarriorAttackRage(entity);
+            grantResolvedAttackResource(entity);
             queueCombatEvent({
                 sourceId: entity.id,
                 targetId: target.id,
@@ -1184,11 +1199,8 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
             ttlTicks: COMBAT_EVENT_TICKS,
         });
 
-        grantWarriorAttackRage(entity);
-
-        if (target.class === "Warrior") {
-            target.currentResource = Decimal.min(target.maxResource, target.currentResource.plus(WARRIOR_RAGE_WHEN_HIT));
-        }
+        grantResolvedAttackResource(entity);
+        grantTakeDamageResource(target);
 
         const critSuffix = isCrit ? " (CRIT)" : "";
         logMessages.push(`${entity.name} uses ${action.name} on ${target.name} for ${finalDamage.floor().toString()}!${critSuffix}${damageSuffix}`);

--- a/src/game/entity.ts
+++ b/src/game/entity.ts
@@ -1,5 +1,8 @@
 import Decimal from "decimal.js";
 
+import { getHeroClassTemplate } from "./classTemplates";
+export { HERO_CLASSES } from "./classTemplates";
+
 // Basic Types
 export type EntityClass = "Warrior" | "Cleric" | "Archer" | "Monster";
 export type HeroClass = Exclude<EntityClass, "Monster">;
@@ -106,17 +109,9 @@ export const BASE_META_UPGRADES: MetaUpgrades = {
     training: 0,
     fortification: 0,
 };
-
-export const HERO_CLASSES: HeroClass[] = ["Warrior", "Cleric", "Archer"];
 export const BOSS_VITALITY_MULTIPLIER = 2;
 export const BOSS_STRENGTH_MULTIPLIER = 1.3;
 export const ENEMY_ELEMENTS: EnemyElement[] = ["fire", "water", "earth", "air", "light", "shadow"];
-
-const HERO_NAME_POOLS: Record<HeroClass, string[]> = {
-    Warrior: ["Brom", "Tarin", "Mira", "Hale", "Sable"],
-    Cleric: ["Lyra", "Seren", "Ione", "Thess", "Aster"],
-    Archer: ["Kestrel", "Nyx", "Corin", "Vera", "Pike"],
-};
 
 const OFFENSIVE_ENEMY_ARCHETYPES: Array<Exclude<EnemyArchetype, "Support" | "Boss">> = ["Bruiser", "Skirmisher", "Caster"];
 
@@ -299,15 +294,17 @@ export const STAT_MULTS = {
     TENACITY_PER_WIS: 1,
 };
 
+export const isHeroClass = (entityClass: EntityClass): entityClass is HeroClass => entityClass !== "Monster";
+
+const cloneAttributes = (attributes: Attributes): Attributes => ({ ...attributes });
+
 // Start Stats Helpers
 export const getBaseAttributes = (entityClass: EntityClass): Attributes => {
-    switch (entityClass) {
-        case "Warrior": return { vit: 10, str: 10, dex: 5, int: 3, wis: 3 };
-        case "Cleric": return { vit: 7, str: 4, dex: 4, int: 8, wis: 10 };
-        case "Archer": return { vit: 6, str: 5, dex: 12, int: 4, wis: 4 };
-        case "Monster": return { vit: 5, str: 5, dex: 5, int: 5, wis: 5 }; // Base, scaled later
-        default: return { vit: 5, str: 5, dex: 5, int: 5, wis: 5 };
+    if (isHeroClass(entityClass)) {
+        return cloneAttributes(getHeroClassTemplate(entityClass).baseAttributes);
     }
+
+    return { vit: 5, str: 5, dex: 5, int: 5, wis: 5 };
 };
 
 export const getExpRequirement = (level: number): Decimal => {
@@ -317,6 +314,7 @@ export const getExpRequirement = (level: number): Decimal => {
 
 export const calculateDerivedStats = (entity: Entity, prestigeUpgrades?: PrestigeUpgrades): Entity => {
     const attrs = entity.attributes;
+    const template = isHeroClass(entity.class) ? getHeroClassTemplate(entity.class) : null;
 
     // Base logic for HP
     // Vitality Prestige adds +1 HP per VIT point per level
@@ -328,22 +326,20 @@ export const calculateDerivedStats = (entity: Entity, prestigeUpgrades?: Prestig
     entity.armor = new Decimal(attrs.str * STAT_MULTS.ARMOR_PER_STR).plus(attrs.vit * STAT_MULTS.ARMOR_PER_VIT);
 
     // Damage
-    entity.physicalDamage = new Decimal(10).plus(
-        entity.class === "Archer" ? attrs.dex * STAT_MULTS.RANGED_DMG_PER_DEX : attrs.str * STAT_MULTS.PHYS_DMG_PER_STR
-    );
+    const physicalDamageSourceAttribute = template?.combatProfile.physicalDamageSourceAttribute ?? "str";
+    const physicalDamageSourceMultiplier = template?.combatProfile.physicalDamageSourceMultiplier ?? STAT_MULTS.PHYS_DMG_PER_STR;
+    entity.physicalDamage = new Decimal(10).plus(attrs[physicalDamageSourceAttribute] * physicalDamageSourceMultiplier);
     entity.magicDamage = new Decimal(5).plus(attrs.int * STAT_MULTS.MAGIC_DMG_PER_INT);
 
     // Resource (Mana/Cunning/Rage)
-    if (entity.class === "Warrior") {
-        entity.maxResource = new Decimal(100); // Fixed rage
-    } else {
-        entity.maxResource = new Decimal(50).plus(attrs.int * STAT_MULTS.RESOURCE_PER_INT);
-    }
+    const maxResourceBase = template?.resourceModel.maxBase ?? 100;
+    const maxResourcePerInt = template?.resourceModel.maxPerInt ?? 0;
+    entity.maxResource = new Decimal(maxResourceBase).plus(attrs.int * maxResourcePerInt);
     if (entity.currentResource.gt(entity.maxResource)) entity.currentResource = entity.maxResource;
 
     // Crit
     entity.critChance = Math.min(0.05 + (attrs.dex * STAT_MULTS.CRIT_CHANCE_PER_DEX), 1.0); // Cap at 100%
-    entity.critDamage = entity.class === "Archer" ? 2.0 : 1.5;
+    entity.critDamage = template?.combatProfile.critMultiplier ?? 1.5;
 
     // Combat ratings
     entity.accuracyRating = 50 + (attrs.dex * STAT_MULTS.ACCURACY_PER_DEX) + (attrs.int * STAT_MULTS.ACCURACY_PER_INT);
@@ -400,14 +396,15 @@ export const createHero = (
     upgrades: MetaUpgrades = BASE_META_UPGRADES,
     prestigeUpgrades?: PrestigeUpgrades,
 ): Entity => {
+    const template = getHeroClassTemplate(entityClass);
     let hero: Entity = {
         id, name, class: entityClass,
         isEnemy: false,
-        image: `${import.meta.env.BASE_URL}assets/hero_${entityClass.toLowerCase()}.png`, // placeholder
+        image: `${import.meta.env.BASE_URL}${template.imageAsset}`,
         level: 1,
         exp: new Decimal(0),
         expToNext: getExpRequirement(1),
-        attributes: getBaseAttributes(entityClass),
+        attributes: cloneAttributes(template.baseAttributes),
         maxHp: new Decimal(1), currentHp: new Decimal(1),
         maxResource: new Decimal(1), currentResource: new Decimal(0), // Rage starts at 0, others start full
         armor: new Decimal(0), physicalDamage: new Decimal(0), magicDamage: new Decimal(0),
@@ -423,8 +420,7 @@ export const createHero = (
     };
 
     hero = recalculateEntity(hero, upgrades, prestigeUpgrades);
-    // Fill resources (except warrior rage)
-    if (entityClass === "Cleric" || entityClass === "Archer") {
+    if (template.resourceModel.startsFull) {
         hero.currentResource = hero.maxResource;
     }
     hero.currentHp = hero.maxHp;
@@ -456,7 +452,7 @@ const getNextHeroId = (heroes: Entity[]): string => {
 
 const getGeneratedHeroName = (entityClass: HeroClass, heroes: Entity[]): string => {
     const existingNames = new Set(heroes.map((hero) => hero.name));
-    const namePool = HERO_NAME_POOLS[entityClass];
+    const namePool = getHeroClassTemplate(entityClass).namePool;
 
     for (const candidate of namePool) {
         if (!existingNames.has(candidate)) {

--- a/src/game/partyProgression.ts
+++ b/src/game/partyProgression.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js";
 
+import { HERO_CLASSES } from "./entity";
 import type { HeroClass } from "./entity";
 
 export interface PartySlotUnlock {
@@ -10,7 +11,7 @@ export interface PartySlotUnlock {
 
 export const MAX_PARTY_SIZE = 5;
 
-export const RECRUITABLE_CLASSES: HeroClass[] = ["Warrior", "Cleric", "Archer"];
+export const RECRUITABLE_CLASSES: HeroClass[] = HERO_CLASSES;
 
 export const PARTY_SLOT_UNLOCKS: PartySlotUnlock[] = [
     { capacity: 2, milestoneFloor: 3, cost: 60 },


### PR DESCRIPTION
## Summary
This PR implements #69 and continues the combat-identity foundation tracked under umbrella #65.

The repo had already accepted the layered combat direction in the architecture docs, but current hero class identity was still scattered across unrelated branches: base attributes in entity construction, level-up growth in the simulation reward path, resource behavior in multiple lifecycle spots, and combat package decisions in ad hoc class conditionals. That made the shipped Warrior, Cleric, and Archer harder to reason about and left future classes without one clear source of truth.

This change introduces explicit hero class templates and then routes the existing hero flow through them. The goal is not to make every future class completely declarative in one shot, but to centralize the current package data so adding or refactoring a class becomes much more data-led than branch-led.

## What Changed
- Added `src/game/classTemplates.ts` as the single source of truth for current hero-class metadata, base attributes, growth packages, resource models, baseline combat tendencies, and action-package identifiers.
- Refactored hero creation, recruit naming, recruitable class lists, resource bar colors, wipe-time resource reset, per-tick resource regen, level-up growth, and hero attack-package selection to read from templates instead of scattered class conditionals.
- Kept the current Warrior, Cleric, and Archer combat behavior intact while moving the owning data into templates.
- Added a new regression test covering template-driven level-up growth after combat rewards.
- Added architecture record `008 - Hero Class Templates, Growth Packages, and Resource Models` and aligned related docs to the implemented state.

## User Impact
Players should not see a gameplay regression from this PR. The visible game behavior for the current three classes remains the same, but the code path that produces that behavior is now easier to extend safely. That gives follow-up work a cleaner footing for new classes and for the layered stat-sourcing refactor in #70.

## Root Cause
Class identity had been evolving incrementally, so the repo accumulated multiple hero-class decision points in different subsystems. Even when the values matched, there was no single authoritative template for "what is a Warrior / Cleric / Archer package", which increased the chance of drift as the combat model grew.

## Validation
- Ran `npm run lint`.
- Ran `npm test`.
- Ran `npm run build`.

## Issue Links
- Implements #69
- Continues umbrella #65
