### PR TITLE
[codex] Refactor derived stat sourcing to layered combat ratings

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/002-attributes-and-stats.md
+++ b/docs/ARCHITECTURE/gamedecisions/002-attributes-and-stats.md
@@ -52,7 +52,7 @@ These are the places where direct primary-stat influence remains desirable becau
 
 ### What Moves to Layered Combat Ratings
 
-The following outputs are accepted as layered-rating-facing in the long-term model, even where the current runtime still derives them mostly from attributes:
+The following outputs are accepted as layered-rating-facing in the long-term model and are now routed through those ratings in the current runtime:
 
 * raw damage packages
 * hit reliability
@@ -66,25 +66,37 @@ The following outputs are accepted as layered-rating-facing in the long-term mod
 
 The MVP layered ratings for that transition are defined in [007 - Layered Combat Model](007-layered-combat-model.md): `power`, `spellPower`, `precision`, `haste`, `guard`, `resolve`, `potency`, and `crit`.
 
-## Transitional Runtime Baseline
+## Current Runtime Baseline
 
-The live game still calculates most combat-facing outputs directly from the five primary attributes. Those formulas remain the canonical current runtime until implementation issue `#70` moves the code to layered stat sourcing.
+The live game now derives most combat-facing outputs through a small layered-rating pass instead of treating the five primary attributes as the direct owner of every final combat number.
+
+At runtime, each entity first computes the accepted MVP secondary ratings from attributes plus a lightweight template or archetype bias package:
+
+* **`power`:** `(sourceAttribute * sourceMultiplier * 0.8) + (STR * 0.25) + (VIT * 0.15) + powerBias`
+* **`spellPower`:** `(INT * 1.25) + (WIS * 0.55) + spellPowerBias`
+* **`precision`:** `(DEX * 0.6) + (INT * 0.35) + (WIS * 0.15) + precisionBias`
+* **`haste`:** `(DEX * 0.45) + (VIT * 0.15) + (WIS * 0.1) + hasteBias`
+* **`guard`:** `(VIT * 0.8) + (STR * 0.55) + (DEX * 0.1) + guardBias`
+* **`resolve`:** `(WIS * 0.85) + (VIT * 0.3) + (INT * 0.35) + resolveBias`
+* **`potency`:** `(INT * 0.45) + (WIS * 0.35) + (DEX * 0.15) + potencyBias`
+* **`crit`:** `(DEX * 0.35) + (WIS * 0.15) + (INT * 0.1) + critBias`
+
+For heroes, the bias package comes from the class template. For enemies, it comes from the current archetype package.
 
 ### Current Derived Stat Formulas
 
-When a unit is created or levels up, the current runtime derives the following baseline stats:
+When a unit is created or levels up, the current runtime derives the following final combat stats from those ratings:
 
 * **Max Health (HP):** `50 + (VIT * 10)`
-* **Armor:** `(STR * 1) + (VIT * 0.5)`
-* **Physical Damage (melee):** `10 + (STR * 1.5)`
-* **Physical Damage (archer basics):** `10 + (DEX * 1.5)`
-* **Magic Damage:** `5 + (INT * 2.0)`
-* **Accuracy Rating:** `50 + (DEX * 1.5) + (INT * 1.0)`
-* **Evasion Rating:** `35 + (DEX * 1.0) + (WIS * 1.0)`
-* **Parry Rating:** `(STR * 1.75) + (DEX * 0.25)`
-* **Armor Penetration:** `(STR * 1.0) + (DEX * 0.5)`
-* **Elemental Penetration:** `(INT * 1.0) + (WIS * 0.5)`
-* **Tenacity:** `(VIT * 0.75) + (WIS * 1.0)`
+* **Armor:** `(STR * 0.45) + (VIT * 0.25) + (guard * 0.4)`
+* **Physical Damage:** `10 + (power * 0.8) + (crit * 0.15)`
+* **Magic Damage:** `5 + (spellPower * 0.75) + (potency * 0.15)`
+* **Accuracy Rating:** `50 + (precision * 1.2) + (crit * 0.1)`
+* **Evasion Rating:** `35 + (haste * 0.8) + (resolve * 0.25)`
+* **Parry Rating:** `(guard * 0.8) + (precision * 0.2)`
+* **Armor Penetration:** `(power * 0.5) + (guard * 0.12)`
+* **Elemental Penetration:** `(spellPower * 0.22) + (potency * 0.4) + (precision * 0.08)`
+* **Tenacity:** `(resolve * 0.65) + (guard * 0.2)`
 
 ### Current Class Resource Baselines
 
@@ -100,8 +112,9 @@ These are still acceptable as attribute-facing baselines. The layered model does
 
 To keep the live game stable under idle scaling, the runtime currently applies the following caps and bounded formulas:
 
-* **Critical Hit Chance:** base `5%`, gains `+0.5%` per DEX, hard capped at `100%`
-* **Elemental Resistances:** `+1%` per WIS, hard capped at `75%`
+* **Critical Hit Chance:** base `5%`, gains `+0.55%` per `crit`, hard capped at `100%`
+* **Critical Hit Damage:** class crit multiplier plus `min(0.2, crit * 0.01)`
+* **Elemental Resistances:** `2% + (resolve * 0.8%)`, hard capped at `75%`
 * **Physical / Ranged Hit Chance:** `clamp(72%, 97%, 82% + (attacker.Accuracy - defender.Evasion) * 0.2%)`
 * **Spell Hit Chance:** `clamp(74%, 96%, 82% + (attacker.Accuracy - defender.Evasion) * 0.16% + (attacker.INT - defender.WIS) * 0.08%)`
 * **Parry Chance:** melee-physical only, `clamp(0%, 25%, 4% + (defender.Parry - attacker.Accuracy * 0.3) * 0.25%)`
@@ -113,7 +126,7 @@ These numbers intentionally match the current runtime, including the spell-hit c
 
 ## Combat Role Implications
 
-While the runtime still routes many results directly through attributes, the accepted design intent is now:
+The current runtime now routes those results through layered ratings while keeping the broad class intent intact:
 
 * **Warrior:** keeps the strongest baseline `guard` tendency through VIT/STR-heavy starts and growth
 * **Cleric:** keeps the strongest baseline `spellPower` and `resolve` tendency through INT/WIS-heavy starts and growth
@@ -126,4 +139,4 @@ This keeps broad class readability while opening space for later template, talen
 
 * **Easier:** The five primary attributes stay readable for players and designers because they remain broad identity stats instead of expanding into a giant new primary-stat roster.
 * **Easier:** Follow-up issues can move overloaded outputs into layered ratings without first redefining how heroes are created or how enemies are scaled.
-* **Difficult:** During the transition period, the docs must distinguish between the accepted long-term ownership model and the current live runtime formulas so we do not accidentally treat temporary math as permanent design.
+* **Difficult:** Docs and code now need to stay aligned at the coefficient level because class-template biases and rating formulas both materially shape combat identity.

--- a/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
+++ b/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
@@ -14,7 +14,7 @@ We implemented an Active Time Battle (ATB) system to manage turn order and actio
 As of [007 - Layered Combat Model](007-layered-combat-model.md), this record serves two jobs:
 
 * document the current live runtime combat flow
-* define which parts of that flow will be owned by layered combat ratings instead of raw attributes as follow-up issues land
+* define which parts of that flow are now owned by layered combat ratings instead of raw attributes alone
 
 ### Game Tick and ATB Scaling
 
@@ -27,10 +27,10 @@ If `Autofight` is disabled, the simulation pauses in place: ATB does not fill, a
 `Autoadvance` is a separate control. When enabled, the party moves to the next floor after winning an encounter. When disabled, the party immediately starts a fresh encounter on the same floor, allowing the player to continuously farm a target floor without climbing past it.
 
 * **Base ATB Rate:** `2.0` per tick.
-* **Speed Bonus:** Dexterity provides a speed bonus calculation: `+ (DEX * 0.06)` per tick.
+* **Speed Bonus:** layered `haste` provides a speed bonus calculation: `+ (haste * 0.08)` per tick.
 * **Status Timing:** reusable timed effects decrement once per game tick, while periodic effects such as Burn resolve once per second (`20` ticks).
 
-This DEX-based speed bonus remains the live runtime baseline. In the accepted layered model, long-term ATB speed ownership moves to `haste`, with core attributes remaining only one input into that final rating.
+`haste` is derived from attributes plus template or archetype bias, so DEX still matters, but it no longer owns action speed by itself.
 
 When an entity's `actionProgress` reaches or exceeds `100`, they consume their bar (reset to `0`) and perform an action.
 
@@ -57,9 +57,9 @@ Currently, action resolution uses a lightweight class-aware ruleset:
 6. **Damage Roll:**
    * Clerics use their `Magic Damage` stat when attacking.
    * Warriors and Archers use their `Physical Damage` stat.
-7. **Critical Hit Check:** The unit's `Crit Chance` (base 5%, boosted by DEX) is rolled. If successful, damage is multiplied.
-   * Archers have a `2.0x` Crit Multiplier.
-   * All other classes have a `1.5x` Crit Multiplier.
+7. **Critical Hit Check:** The unit's `Crit Chance` (base `5%`, boosted by layered `crit`) is rolled. If successful, damage is multiplied.
+   * The current runtime adds `+0.55%` crit chance per `crit` rating.
+   * Crit damage starts from the class template multiplier and gains a small layered bonus through `min(0.2, crit * 0.01)`.
 8. **Mitigation:** The final incoming damage is reduced based on the action's specific `DamageElement` tag. If the element is `physical`, the attacker's `Armor Penetration` first converts through `min(60%, penetration / (penetration + 60))` and reduces the target's effective armor by that proportion, then damage is reduced with the existing diminishing-return armor curve: `rawDamage * (100 / (100 + effectiveArmor * 2))`. If the element is magical (e.g. `light`, `fire`), the attacker's `Elemental Penetration` uses the same bounded conversion to reduce the target's effective elemental resistance before the percentage-based resistance reduction is applied. Minimum damage remains `1`.
 9. **Status Application:** After a damaging elemental hit lands and deals damage, the engine may apply a timed status rider. The current element-to-status mappings are `fire -> Burn`, `water -> Slow`, `earth -> Weaken`, `shadow -> Hex`, and `light -> Blind`. Application uses `clamp(15%, 75%, baseChance + (attacker.ElementalPenetration - defender.Tenacity) * 0.3%)`, so elemental pressure stays bounded and shares the same offensive/defensive stats as spell damage.
 10. **Protection Effects:** `Ward Ally` remains a lightweight support-only protection effect. It reduces the next damaging hit against the warded target by `35%`, then expires immediately. It still lives outside the timed-status framework because it is a single-hit shield, not a duration-based condition.
@@ -121,21 +121,21 @@ The first deeper-combat pass uses bounded formulas to stay stable under long-ter
 * **Penetration Reduction:** `min(60%, penetration / (penetration + 60))`
 * **Tenacity Reduction:** `min(60%, tenacity / (tenacity + 80))`
 
-These formulas are the current runtime baseline and are intentionally preserved as bounded shapes for the layered follow-up work.
+These formulas are the current runtime baseline and remain intentionally bounded after the layered-stat sourcing refactor.
 
 ### Accepted Layered Ownership
 
 The layered combat pass does not replace the ATB combat loop itself. It changes which systems own the final combat numbers that feed the loop:
 
 * **`precision`:** owns hit reliability pressure. Physical and spell hit formulas remain contested and clamped, but future offensive hit strength should flow primarily through `precision` rather than raw DEX or INT alone.
-* **`haste`:** owns long-term action-speed pressure. The current DEX-based ATB bonus is a baseline placeholder until layered stat sourcing lands.
+* **`haste`:** owns long-term action-speed pressure. The runtime now routes ATB gain through `haste`, with DEX remaining only one contributor to that final rating.
 * **`crit`:** owns crit chance and crit bonus pressure. Crits remain bounded and continue to be softened defensively rather than removed outright.
 * **`guard`:** owns physical durability packages, especially armor-facing mitigation and parry-facing melee defense.
 * **`resolve`:** owns magical durability packages, including elemental resistance baselines and tenacity-facing anti-spike / anti-status resistance.
 * **`potency`:** owns bypass and application pressure, especially penetration and elemental status application pressure.
 * **`power` / `spellPower`:** own the outgoing damage packages that feed the mitigation pipeline, with `spellPower` also owning healing throughput.
 
-Follow-up issue `#70` should preserve the same readability and boundedness even as these systems stop being mostly direct primary-stat products.
+Implementation issue `#70` preserves the same readability and boundedness while moving these systems away from mostly direct primary-stat products.
 
 ### Combat Readability
 
@@ -164,4 +164,4 @@ The combat loop now advances through a provider-backed `zustand` store action (`
 ## Consequences
 
 * **Easier:** Combat remains readable and less deterministic, while the accepted layered model now gives later issues a clear place to move hit, speed, crit, mitigation, and status ownership without redesigning the ATB loop itself.
-* **Difficult:** Until `#70` lands, many of these systems still scale from shared attributes in runtime. Future combat additions should continue to prefer bounded formulas and explicit caps rather than open-ended avoidance stacking, stun chains, or mitigation bypass that fully invalidates earlier systems.
+* **Difficult:** Future combat additions should continue to prefer bounded formulas and explicit caps rather than open-ended avoidance stacking, stun chains, or mitigation bypass that fully invalidates earlier systems.

--- a/docs/ARCHITECTURE/gamedecisions/007-layered-combat-model.md
+++ b/docs/ARCHITECTURE/gamedecisions/007-layered-combat-model.md
@@ -78,9 +78,9 @@ Follow-up implementation issues should keep the existing bounded style of combat
 
 This keeps the combat model idle-readable and reduces runaway scaling risk.
 
-### Transitional Baseline
+### Current Runtime Baseline
 
-The current runtime still derives many combat outputs directly from `VIT`, `STR`, `DEX`, `INT`, and `WIS`. That is acceptable during the transition. Existing formulas documented in [002 - Attributes and Derived Stats](002-attributes-and-stats.md) and [003 - Combat Loop and ATB Mechanics](003-combat-and-atb.md) should be treated as the live baseline until implementation issue `#70` moves the code to layered stat sourcing.
+Implementation issue `#70` now derives combat-facing outputs through the MVP layered ratings documented here. Attributes still seed those ratings, but the runtime now also applies template or archetype bias packages before converting them into final hit, speed, crit, penetration, resistance, and status-facing numbers. Existing formulas documented in [002 - Attributes and Derived Stats](002-attributes-and-stats.md) and [003 - Combat Loop and ATB Mechanics](003-combat-and-atb.md) are the canonical live baseline.
 
 ### Follow-up Issue Boundaries
 
@@ -95,5 +95,5 @@ This decision intentionally sets boundaries for the rest of the foundation work:
 
 * **Easier:** Future classes gain a cleaner design space because class identity can live in templates and layered ratings instead of mostly in raw attribute emphasis.
 * **Easier:** Talents and equipment now have a clear destination for targeted build differentiation without forcing a new set of primary attributes.
-* **Easier:** The current runtime can transition incrementally because this record locks ownership and boundaries before coefficient-level refactors happen.
-* **Difficult:** The system now has a stronger conceptual distinction between foundation stats and combat ratings, so docs and code must stay aligned during the transition period.
+* **Easier:** The current runtime could transition incrementally because this record locked ownership and boundaries before coefficient-level refactors happened.
+* **Difficult:** The system now has a stronger conceptual distinction between foundation stats and combat ratings, so docs and code must stay aligned as future tuning continues.

--- a/docs/ARCHITECTURE/gamedecisions/008-hero-class-templates.md
+++ b/docs/ARCHITECTURE/gamedecisions/008-hero-class-templates.md
@@ -34,7 +34,7 @@ Each hero template includes:
 * **Base attributes:** the level-1 starting identity package
 * **Growth package:** the attribute increments applied on each level-up
 * **Resource model:** resource type, starting state, maximum-resource formula inputs, per-tick regeneration, and any resource triggers such as on-hit or on-attack gains
-* **Combat profile:** current basic-action identity, crit multiplier, physical damage source attribute, and baseline combat-rating tendencies
+* **Combat profile:** current basic-action identity, crit multiplier, physical damage source attribute, baseline combat-rating tendencies, and numeric rating-bias package for the layered combat pass
 * **Action package:** the current package id plus the data needed for the package's shipped special actions or support actions
 
 ### Current Hero Packages
@@ -42,6 +42,14 @@ Each hero template includes:
 * **Warrior:** STR/VIT-heavy bruiser package with Rage-based burst and resource gains tied to combat participation
 * **Cleric:** INT/WIS-heavy support package with Mana regeneration, triage healing, Bless/Regen support, and Light spell pressure
 * **Archer:** DEX-heavy ranged package with fast Cunning regeneration and crit-oriented burst shots
+
+### Current Layered Rating Bias Packages
+
+The first runtime follow-through for issue `#70` uses these templates as explicit combat-rating sources:
+
+* **Warrior:** `power +6`, `guard +8`, `haste +1`
+* **Cleric:** `spellPower +8`, `precision +2`, `resolve +9`, `potency +6`, `crit +2`
+* **Archer:** `power +4`, `precision +9`, `haste +8`, `potency +2`, `crit +8`
 
 ### Scope Boundaries
 
@@ -57,7 +65,7 @@ That tradeoff is intentional for the first pass:
 This decision is the implementation follow-through for issue `#69`.
 
 * `#69` centralizes current class identity into explicit templates
-* `#70` will use those templates as one of the layered stat sources when combat ratings stop being mostly raw attribute products
+* `#70` now uses those templates as one of the layered stat sources when combat ratings are recomputed
 
 ## Consequences
 

--- a/src/game/classTemplates.ts
+++ b/src/game/classTemplates.ts
@@ -73,6 +73,7 @@ export interface HeroCombatProfile {
     critMultiplier: number;
     basicAction: HeroBasicActionDefinition;
     baselineRatings: HeroCombatRating[];
+    ratingBiases: Partial<Record<HeroCombatRating, number>>;
 }
 
 export interface HeroClassTemplate {
@@ -121,6 +122,11 @@ export const HERO_CLASS_TEMPLATES: Record<HeroClass, HeroClassTemplate> = {
                 canParry: true,
             },
             baselineRatings: ["guard", "power"],
+            ratingBiases: {
+                power: 6,
+                guard: 8,
+                haste: 1,
+            },
         },
         actionPackage: {
             id: "warrior",
@@ -167,6 +173,13 @@ export const HERO_CLASS_TEMPLATES: Record<HeroClass, HeroClassTemplate> = {
                 canParry: false,
             },
             baselineRatings: ["spellPower", "resolve"],
+            ratingBiases: {
+                spellPower: 8,
+                precision: 2,
+                resolve: 9,
+                potency: 6,
+                crit: 2,
+            },
         },
         actionPackage: {
             id: "cleric",
@@ -216,6 +229,13 @@ export const HERO_CLASS_TEMPLATES: Record<HeroClass, HeroClassTemplate> = {
                 canParry: false,
             },
             baselineRatings: ["precision", "haste", "crit"],
+            ratingBiases: {
+                power: 4,
+                precision: 9,
+                haste: 8,
+                potency: 2,
+                crit: 8,
+            },
         },
         actionPackage: {
             id: "archer",

--- a/src/game/engine/simulation.test.ts
+++ b/src/game/engine/simulation.test.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js";
 import { describe, expect, it } from "vitest";
 
-import { createEnemy, createHero } from "../entity";
+import { createEnemy, createHero, recalculateEntity } from "../entity";
 
 import {
     applyElementalMitigation,
@@ -11,6 +11,7 @@ import {
     createSequenceRandomSource,
     getEffectiveCritMultiplier,
     getEncounterSize,
+    getActionProgressPerTick,
     getPhysicalHitChance,
     getPenetrationReduction,
     getSpellHitChance,
@@ -516,6 +517,28 @@ describe("simulation engine", () => {
         expect(getEffectiveCritMultiplier(2, 0)).toBeCloseTo(2);
         expect(getEffectiveCritMultiplier(2, 10_000)).toBeCloseTo(1.4);
         expect(getEffectiveCritMultiplier(1.5, 10_000)).toBeGreaterThan(1);
+    });
+
+    it("uses template-backed ratings for speed, hit pressure, and status pressure even with matched attributes", () => {
+        const sharedAttributes = { vit: 8, str: 6, dex: 9, int: 6, wis: 6 };
+        const warrior = createHero("hero_1", "Brom", "Warrior");
+        const cleric = createHero("hero_2", "Ayla", "Cleric");
+        const archer = createHero("hero_3", "Vera", "Archer");
+        const enemy = createEnemy(8, "enemy_1");
+
+        warrior.attributes = { ...sharedAttributes };
+        cleric.attributes = { ...sharedAttributes };
+        archer.attributes = { ...sharedAttributes };
+
+        recalculateEntity(warrior);
+        recalculateEntity(cleric);
+        recalculateEntity(archer);
+
+        expect(getActionProgressPerTick(archer)).toBeGreaterThan(getActionProgressPerTick(warrior));
+        expect(getActionProgressPerTick(warrior)).toBeGreaterThan(getActionProgressPerTick(cleric));
+        expect(getPhysicalHitChance(archer, enemy)).toBeGreaterThan(getPhysicalHitChance(warrior, enemy));
+        expect(getSpellHitChance(cleric, enemy)).toBeGreaterThan(getSpellHitChance(warrior, enemy));
+        expect(getStatusApplicationChance(cleric, enemy, 0.45)).toBeGreaterThan(getStatusApplicationChance(warrior, enemy, 0.45));
     });
 
     it("keeps spell hit only modestly above physical hit for the same matchup", () => {

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -4,6 +4,7 @@ import { getHeroClassTemplate } from "../classTemplates";
 import {
     BASE_META_UPGRADES,
     createEnemy,
+    getCombatRatings,
     getEncounterArchetypes,
     getEnemyElementForEncounter,
     getExpRequirement,
@@ -19,7 +20,7 @@ import type { CombatEvent, GameState } from "../store/types";
 export const GAME_TICK_RATE = 20;
 export const GAME_TICK_MS = 1000 / GAME_TICK_RATE;
 export const ATB_RATE = 2;
-export const DEX_ATB_RATE = 0.06;
+export const HASTE_ATB_RATE = 0.08;
 export const WARRIOR_RAGE_STRIKE_COST = getHeroClassTemplate("Warrior").actionPackage.specialAttack?.cost ?? 40;
 export const WARRIOR_RAGE_PER_ATTACK = getHeroClassTemplate("Warrior").resourceModel.gainOnResolvedAttack;
 export const WARRIOR_RAGE_WHEN_HIT = getHeroClassTemplate("Warrior").resourceModel.gainOnTakeDamage;
@@ -391,6 +392,12 @@ const getDamageOutputMultiplier = (entity: Entity) => {
 
 const getAtbMultiplier = (entity: Entity) => {
     return Math.max(0.1, 1 - getStatusPotency(entity, "slow"));
+};
+
+export const getActionProgressPerTick = (entity: Entity, prestigeUpgrades?: Pick<PrestigeUpgrades, "gameSpeed">) => {
+    const hasteBonus = (prestigeUpgrades?.gameSpeed ?? 0) * 0.1;
+    const combatRatings = getCombatRatings(entity);
+    return (ATB_RATE + (combatRatings.haste * HASTE_ATB_RATE)) * (1 + hasteBonus) * getAtbMultiplier(entity);
 };
 
 /** Returns a multiplier (0–1) reducing incoming healing by the target's hex potency. */
@@ -990,8 +997,7 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
             return;
         }
 
-        const hasteBonus = draft.prestigeUpgrades.gameSpeed * 0.1; // +10% speed up per level
-        entity.actionProgress += (ATB_RATE + (entity.attributes.dex * DEX_ATB_RATE)) * (1 + hasteBonus) * getAtbMultiplier(entity);
+        entity.actionProgress += getActionProgressPerTick(entity, draft.prestigeUpgrades);
         const heroTemplate = getHeroTemplateForEntity(entity);
 
         if (heroTemplate) {

--- a/src/game/entity.test.ts
+++ b/src/game/entity.test.ts
@@ -5,10 +5,12 @@ import {
     BOSS_STRENGTH_MULTIPLIER,
     BOSS_VITALITY_MULTIPLIER,
     createEnemy,
+    getCombatRatings,
     createHero,
     createRecruitHero,
     createStarterParty,
     getEnemyArchetypeLabel,
+    recalculateEntity,
 } from "./entity";
 
 describe("entity model", () => {
@@ -42,16 +44,51 @@ describe("entity model", () => {
         expect(upgraded.armor.gt(baseline.armor)).toBe(true);
     });
 
-    it("derives combat ratings, penetration, and tenacity from existing attributes", () => {
+    it("derives layered combat ratings and final combat stats from attributes plus class packages", () => {
         const warrior = createHero("hero_1", "Brom", "Warrior");
+        const warriorRatings = getCombatRatings(warrior);
 
-        expect(warrior.accuracyRating).toBeCloseTo(60.5);
-        expect(warrior.evasionRating).toBeCloseTo(43);
-        expect(warrior.parryRating).toBeCloseTo(18.75);
-        expect(warrior.armorPenetration).toBeCloseTo(12.5);
-        expect(warrior.elementalPenetration).toBeCloseTo(4.5);
-        expect(warrior.tenacity).toBeCloseTo(10.5);
+        expect(warriorRatings.power).toBeCloseTo(22);
+        expect(warriorRatings.precision).toBeCloseTo(4.5);
+        expect(warriorRatings.haste).toBeCloseTo(5.05);
+        expect(warriorRatings.guard).toBeCloseTo(22);
+        expect(warriorRatings.resolve).toBeCloseTo(6.6);
+        expect(warriorRatings.potency).toBeCloseTo(3.15);
+        expect(warriorRatings.crit).toBeCloseTo(2.5);
+        expect(warrior.armor.toNumber()).toBeCloseTo(15.8);
+        expect(warrior.physicalDamage.toNumber()).toBeCloseTo(27.98, 2);
+        expect(warrior.magicDamage.toNumber()).toBeCloseTo(9.52, 2);
+        expect(warrior.accuracyRating).toBeCloseTo(55.65);
+        expect(warrior.evasionRating).toBeCloseTo(40.69);
+        expect(warrior.parryRating).toBeCloseTo(18.5);
+        expect(warrior.armorPenetration).toBeCloseTo(13.64);
+        expect(warrior.elementalPenetration).toBeCloseTo(2.81);
+        expect(warrior.tenacity).toBeCloseTo(8.69);
+        expect(warrior.resistances.light).toBeCloseTo(0.0728);
         expect(warrior.statusEffects).toEqual([]);
+    });
+
+    it("preserves warrior, cleric, and archer combat identity even with matched attributes", () => {
+        const sharedAttributes = { vit: 8, str: 6, dex: 9, int: 6, wis: 6 };
+        const warrior = createHero("hero_1", "Brom", "Warrior");
+        const cleric = createHero("hero_2", "Ayla", "Cleric");
+        const archer = createHero("hero_3", "Vera", "Archer");
+
+        warrior.attributes = { ...sharedAttributes };
+        cleric.attributes = { ...sharedAttributes };
+        archer.attributes = { ...sharedAttributes };
+
+        recalculateEntity(warrior);
+        recalculateEntity(cleric);
+        recalculateEntity(archer);
+
+        expect(warrior.armor.gt(archer.armor)).toBe(true);
+        expect(archer.accuracyRating).toBeGreaterThan(warrior.accuracyRating);
+        expect(archer.critChance).toBeGreaterThan(warrior.critChance);
+        expect(archer.physicalDamage.gt(warrior.physicalDamage)).toBe(true);
+        expect(cleric.magicDamage.gt(archer.magicDamage)).toBe(true);
+        expect(cleric.tenacity).toBeGreaterThan(warrior.tenacity);
+        expect(cleric.resistances.shadow).toBeGreaterThan(archer.resistances.shadow);
     });
 
     it("creates tougher boss enemies on every tenth floor with the softened boss multipliers", () => {

--- a/src/game/entity.ts
+++ b/src/game/entity.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js";
 
 import { getHeroClassTemplate } from "./classTemplates";
+import type { HeroCombatRating } from "./classTemplates";
 export { HERO_CLASSES } from "./classTemplates";
 
 // Basic Types
@@ -104,6 +105,8 @@ export interface CreateEnemyOptions {
     boss?: boolean;
     element?: EnemyElement;
 }
+
+export type CombatRatings = Record<HeroCombatRating, number>;
 
 export const BASE_META_UPGRADES: MetaUpgrades = {
     training: 0,
@@ -269,34 +272,65 @@ export const inferEnemyArchetype = (entity: Pick<Entity, "isEnemy" | "enemyArche
     return "Bruiser";
 };
 
+const getEnemyCombatRatingBiases = (entity: Pick<Entity, "isEnemy" | "enemyArchetype" | "name">): Partial<CombatRatings> => {
+    switch (inferEnemyArchetype(entity)) {
+        case "Bruiser":
+            return { power: 3, guard: 5 };
+        case "Skirmisher":
+            return { precision: 5, haste: 5, crit: 4 };
+        case "Caster":
+            return { spellPower: 5, resolve: 2, potency: 4 };
+        case "Support":
+            return { spellPower: 3, resolve: 5, potency: 3 };
+        case "Boss":
+            return { power: 4, spellPower: 4, precision: 3, haste: 3, guard: 4, resolve: 4, potency: 4, crit: 3 };
+        default:
+            return {};
+    }
+};
+
 // Global Stat Multipliers
 export const STAT_MULTS = {
     HP_PER_VIT: 10,
-    ARMOR_PER_STR: 1,
-    ARMOR_PER_VIT: 0.5,
-    PHYS_DMG_PER_STR: 1.5, // For melee
-    RANGED_DMG_PER_DEX: 1.5, // For archers
-    MAGIC_DMG_PER_INT: 2,
+    ARMOR_PER_STR: 0.45,
+    ARMOR_PER_VIT: 0.25,
+    ARMOR_PER_GUARD: 0.4,
+    PHYS_DMG_PER_POWER: 0.8,
+    PHYS_DMG_PER_CRIT: 0.15,
+    MAGIC_DMG_PER_SPELL_POWER: 0.75,
+    MAGIC_DMG_PER_POTENCY: 0.15,
     RESOURCE_PER_INT: 5,
-    CRIT_CHANCE_PER_DEX: 0.005, // 0.5% per Dex
-    RESIST_PER_WIS: 0.01, // 1% per Wis
-    ACCURACY_PER_DEX: 1.5,
-    ACCURACY_PER_INT: 1,
-    EVASION_PER_DEX: 1,
-    EVASION_PER_WIS: 1,
-    PARRY_PER_STR: 1.75,
-    PARRY_PER_DEX: 0.25,
-    ARMOR_PEN_PER_STR: 1,
-    ARMOR_PEN_PER_DEX: 0.5,
-    ELEMENTAL_PEN_PER_INT: 1,
-    ELEMENTAL_PEN_PER_WIS: 0.5,
-    TENACITY_PER_VIT: 0.75,
-    TENACITY_PER_WIS: 1,
+    CRIT_CHANCE_PER_RATING: 0.0055,
+    RESIST_BASE: 0.02,
+    RESIST_PER_RESOLVE: 0.008,
+    ACCURACY_PER_PRECISION: 1.2,
+    ACCURACY_PER_CRIT: 0.1,
+    EVASION_PER_HASTE: 0.8,
+    EVASION_PER_RESOLVE: 0.25,
+    PARRY_PER_GUARD: 0.8,
+    PARRY_PER_PRECISION: 0.2,
+    ARMOR_PEN_PER_POWER: 0.5,
+    ARMOR_PEN_PER_GUARD: 0.12,
+    ELEMENTAL_PEN_PER_SPELL_POWER: 0.22,
+    ELEMENTAL_PEN_PER_POTENCY: 0.4,
+    ELEMENTAL_PEN_PER_PRECISION: 0.08,
+    TENACITY_PER_RESOLVE: 0.65,
+    TENACITY_PER_GUARD: 0.2,
 };
 
 export const isHeroClass = (entityClass: EntityClass): entityClass is HeroClass => entityClass !== "Monster";
 
 const cloneAttributes = (attributes: Attributes): Attributes => ({ ...attributes });
+const createEmptyCombatRatings = (): CombatRatings => ({
+    power: 0,
+    spellPower: 0,
+    precision: 0,
+    haste: 0,
+    guard: 0,
+    resolve: 0,
+    potency: 0,
+    crit: 0,
+});
 
 // Start Stats Helpers
 export const getBaseAttributes = (entityClass: EntityClass): Attributes => {
@@ -312,9 +346,41 @@ export const getExpRequirement = (level: number): Decimal => {
     return new Decimal(100).times(Decimal.pow(1.5, level - 1)).floor();
 };
 
+export const getCombatRatings = (entity: Pick<Entity, "class" | "isEnemy" | "attributes" | "enemyArchetype" | "name">): CombatRatings => {
+    const attrs = entity.attributes;
+    const template = isHeroClass(entity.class) ? getHeroClassTemplate(entity.class) : null;
+    const physicalSourceAttribute = template?.combatProfile.physicalDamageSourceAttribute ?? "str";
+    const physicalSourceMultiplier = template?.combatProfile.physicalDamageSourceMultiplier ?? 1.5;
+
+    const ratings: CombatRatings = {
+        power: (attrs[physicalSourceAttribute] * physicalSourceMultiplier * 0.8) + (attrs.str * 0.25) + (attrs.vit * 0.15),
+        spellPower: (attrs.int * 1.25) + (attrs.wis * 0.55),
+        precision: (attrs.dex * 0.6) + (attrs.int * 0.35) + (attrs.wis * 0.15),
+        haste: (attrs.dex * 0.45) + (attrs.vit * 0.15) + (attrs.wis * 0.1),
+        guard: (attrs.vit * 0.8) + (attrs.str * 0.55) + (attrs.dex * 0.1),
+        resolve: (attrs.wis * 0.85) + (attrs.vit * 0.3) + (attrs.int * 0.35),
+        potency: (attrs.int * 0.45) + (attrs.wis * 0.35) + (attrs.dex * 0.15),
+        crit: (attrs.dex * 0.35) + (attrs.wis * 0.15) + (attrs.int * 0.1),
+    };
+
+    const biasSources: Array<Partial<CombatRatings>> = [
+        template?.combatProfile.ratingBiases ?? createEmptyCombatRatings(),
+        entity.isEnemy ? getEnemyCombatRatingBiases(entity) : createEmptyCombatRatings(),
+    ];
+
+    biasSources.forEach((biases) => {
+        (Object.keys(ratings) as HeroCombatRating[]).forEach((ratingKey) => {
+            ratings[ratingKey] += biases[ratingKey] ?? 0;
+        });
+    });
+
+    return ratings;
+};
+
 export const calculateDerivedStats = (entity: Entity, prestigeUpgrades?: PrestigeUpgrades): Entity => {
     const attrs = entity.attributes;
     const template = isHeroClass(entity.class) ? getHeroClassTemplate(entity.class) : null;
+    const ratings = getCombatRatings(entity);
 
     // Base logic for HP
     // Vitality Prestige adds +1 HP per VIT point per level
@@ -322,14 +388,15 @@ export const calculateDerivedStats = (entity: Entity, prestigeUpgrades?: Prestig
     entity.maxHp = new Decimal(50).plus(attrs.vit * hpPerVit);
     if (entity.currentHp.gt(entity.maxHp)) entity.currentHp = entity.maxHp;
 
-    // Armor
-    entity.armor = new Decimal(attrs.str * STAT_MULTS.ARMOR_PER_STR).plus(attrs.vit * STAT_MULTS.ARMOR_PER_VIT);
-
-    // Damage
-    const physicalDamageSourceAttribute = template?.combatProfile.physicalDamageSourceAttribute ?? "str";
-    const physicalDamageSourceMultiplier = template?.combatProfile.physicalDamageSourceMultiplier ?? STAT_MULTS.PHYS_DMG_PER_STR;
-    entity.physicalDamage = new Decimal(10).plus(attrs[physicalDamageSourceAttribute] * physicalDamageSourceMultiplier);
-    entity.magicDamage = new Decimal(5).plus(attrs.int * STAT_MULTS.MAGIC_DMG_PER_INT);
+    entity.armor = new Decimal(attrs.str * STAT_MULTS.ARMOR_PER_STR)
+        .plus(attrs.vit * STAT_MULTS.ARMOR_PER_VIT)
+        .plus(ratings.guard * STAT_MULTS.ARMOR_PER_GUARD);
+    entity.physicalDamage = new Decimal(10)
+        .plus(ratings.power * STAT_MULTS.PHYS_DMG_PER_POWER)
+        .plus(ratings.crit * STAT_MULTS.PHYS_DMG_PER_CRIT);
+    entity.magicDamage = new Decimal(5)
+        .plus(ratings.spellPower * STAT_MULTS.MAGIC_DMG_PER_SPELL_POWER)
+        .plus(ratings.potency * STAT_MULTS.MAGIC_DMG_PER_POTENCY);
 
     // Resource (Mana/Cunning/Rage)
     const maxResourceBase = template?.resourceModel.maxBase ?? 100;
@@ -337,20 +404,23 @@ export const calculateDerivedStats = (entity: Entity, prestigeUpgrades?: Prestig
     entity.maxResource = new Decimal(maxResourceBase).plus(attrs.int * maxResourcePerInt);
     if (entity.currentResource.gt(entity.maxResource)) entity.currentResource = entity.maxResource;
 
-    // Crit
-    entity.critChance = Math.min(0.05 + (attrs.dex * STAT_MULTS.CRIT_CHANCE_PER_DEX), 1.0); // Cap at 100%
-    entity.critDamage = template?.combatProfile.critMultiplier ?? 1.5;
+    entity.critChance = Math.min(0.05 + (ratings.crit * STAT_MULTS.CRIT_CHANCE_PER_RATING), 1.0);
+    entity.critDamage = (template?.combatProfile.critMultiplier ?? 1.5) + Math.min(0.2, ratings.crit * 0.01);
 
-    // Combat ratings
-    entity.accuracyRating = 50 + (attrs.dex * STAT_MULTS.ACCURACY_PER_DEX) + (attrs.int * STAT_MULTS.ACCURACY_PER_INT);
-    entity.evasionRating = 35 + (attrs.dex * STAT_MULTS.EVASION_PER_DEX) + (attrs.wis * STAT_MULTS.EVASION_PER_WIS);
-    entity.parryRating = (attrs.str * STAT_MULTS.PARRY_PER_STR) + (attrs.dex * STAT_MULTS.PARRY_PER_DEX);
-    entity.armorPenetration = (attrs.str * STAT_MULTS.ARMOR_PEN_PER_STR) + (attrs.dex * STAT_MULTS.ARMOR_PEN_PER_DEX);
-    entity.elementalPenetration = (attrs.int * STAT_MULTS.ELEMENTAL_PEN_PER_INT) + (attrs.wis * STAT_MULTS.ELEMENTAL_PEN_PER_WIS);
-    entity.tenacity = (attrs.vit * STAT_MULTS.TENACITY_PER_VIT) + (attrs.wis * STAT_MULTS.TENACITY_PER_WIS);
+    entity.accuracyRating = 50
+        + (ratings.precision * STAT_MULTS.ACCURACY_PER_PRECISION)
+        + (ratings.crit * STAT_MULTS.ACCURACY_PER_CRIT);
+    entity.evasionRating = 35
+        + (ratings.haste * STAT_MULTS.EVASION_PER_HASTE)
+        + (ratings.resolve * STAT_MULTS.EVASION_PER_RESOLVE);
+    entity.parryRating = (ratings.guard * STAT_MULTS.PARRY_PER_GUARD) + (ratings.precision * STAT_MULTS.PARRY_PER_PRECISION);
+    entity.armorPenetration = (ratings.power * STAT_MULTS.ARMOR_PEN_PER_POWER) + (ratings.guard * STAT_MULTS.ARMOR_PEN_PER_GUARD);
+    entity.elementalPenetration = (ratings.spellPower * STAT_MULTS.ELEMENTAL_PEN_PER_SPELL_POWER)
+        + (ratings.potency * STAT_MULTS.ELEMENTAL_PEN_PER_POTENCY)
+        + (ratings.precision * STAT_MULTS.ELEMENTAL_PEN_PER_PRECISION);
+    entity.tenacity = (ratings.resolve * STAT_MULTS.TENACITY_PER_RESOLVE) + (ratings.guard * STAT_MULTS.TENACITY_PER_GUARD);
 
-    // Resists
-    const resistVal = Math.min(attrs.wis * STAT_MULTS.RESIST_PER_WIS, 0.75); // Cap at 75%
+    const resistVal = Math.min(STAT_MULTS.RESIST_BASE + (ratings.resolve * STAT_MULTS.RESIST_PER_RESOLVE), 0.75);
     entity.resistances = {
         fire: resistVal, water: resistVal, earth: resistVal,
         air: resistVal, light: resistVal, shadow: resistVal


### PR DESCRIPTION
Closes #70.

This refactor moves the live derived-stat pipeline onto the layered combat model so combat identity is no longer owned almost entirely by raw primary attributes, especially Dexterity. Before this change, too many final outputs were sourced straight from `VIT`, `STR`, `DEX`, `INT`, and `WIS`, which made Archer throughput, hit pressure, crit pressure, and ATB speed drift toward the same shared stat pipes. In practice that flattened class identity and left the newer class-template work from `#69` with very little influence over the final combat package.

The root cause was that the current runtime only used class templates for a few combat details like physical damage source and crit multiplier, while nearly every other meaningful combat-facing stat still bypassed the layered model entirely. This patch introduces explicit numeric rating biases on hero templates, adds lightweight archetype bias packages for enemies, and computes `power`, `spellPower`, `precision`, `haste`, `guard`, `resolve`, `potency`, and `crit` as an internal derived layer before converting them into final damage, hit, evasion, parry, penetration, tenacity, resistance, and crit outputs. The ATB tick now consumes layered `haste` instead of raw Dexterity, so speed pressure still scales from attributes but is no longer a single-stat ownership path.

From a player-facing perspective, this keeps Warriors, Clerics, and Archers readable while making their combat identities more distinct even when attribute spreads overlap. Warriors now keep a stronger guard package, Clerics keep spell/resolve/status pressure, and Archers keep speed, precision, and crit identity through the class package itself instead of depending on Dexterity doing all of that work alone. The formulas stay bounded, deterministic, and save-safe because the persisted entity shape is unchanged and the runtime simply recomputes final combat stats from the same stable source attributes and templates.

I also updated the architecture decision records so the documentation reflects the new live formulas and the fact that `#70` is now implemented. The docs now describe the current layered-rating pipeline, the new ATB sourcing, and the template-level rating bias packages that power the shipped hero classes.

Validation:
- `npm test`
- `npm run lint`
- `npm run build`
