### PR TITLE
[codex] Add versioned save migrations for layered progression systems

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
+++ b/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
@@ -101,7 +101,14 @@ If all party members reach 0 HP, a wipe is triggered. The party is fully healed,
 
 ### Save-Safe Expansion Rule
 
-Because future differentiation layers will introduce new progression fields, additive systems in this area must remain migration-safe. The accepted direction in this issue is to define the progression stack now and leave versioned save migration behavior to follow-up issue `#71`.
+Because future differentiation layers introduce new progression fields, additive systems in this area must remain migration-safe.
+
+Issue `#71` implements the current persistence rule:
+
+* save payloads are explicitly versioned
+* older payloads are migrated forward step-by-step before runtime hydration
+* additive progression layers default through named migration steps instead of ad hoc tolerant parsing
+* placeholder progression state for talents and equipment is now part of the canonical save shape, even before those systems have full gameplay behavior
 
 ## Consequences
 

--- a/docs/ARCHITECTURE/gamedecisions/007-layered-combat-model.md
+++ b/docs/ARCHITECTURE/gamedecisions/007-layered-combat-model.md
@@ -96,4 +96,5 @@ This decision intentionally sets boundaries for the rest of the foundation work:
 * **Easier:** Future classes gain a cleaner design space because class identity can live in templates and layered ratings instead of mostly in raw attribute emphasis.
 * **Easier:** Talents and equipment now have a clear destination for targeted build differentiation without forcing a new set of primary attributes.
 * **Easier:** The current runtime could transition incrementally because this record locked ownership and boundaries before coefficient-level refactors happened.
+* **Easier:** Versioned save migrations now give later combat/progression layers an explicit compatibility path instead of relying only on hydration tolerance.
 * **Difficult:** The system now has a stronger conceptual distinction between foundation stats and combat ratings, so docs and code must stay aligned as future tuning continues.

--- a/docs/ARCHITECTURE/technicaldecisions/002-state-management-evolution.md
+++ b/docs/ARCHITECTURE/technicaldecisions/002-state-management-evolution.md
@@ -98,6 +98,7 @@ The migration landed with a compatibility path:
 * `useGame` is retained as a compatibility hook for legacy callers.
 * New and migrated UI components subscribe through `useGameStore(selector)` so unrelated panels do not rerender on every ATB tick.
 * Browser-only persistence now hangs off the provider lifecycle: when no explicit `initialState` is supplied, the provider restores the latest autosave from `localStorage` and writes a fresh JSON save every 10 seconds.
+* Save export/import now flows through an explicit versioned migration layer before runtime hydration. Older payloads are normalized into the current schema first, then handed to `reset(...)`, which keeps future additive progression systems from requiring one-off compatibility hacks in unrelated store code.
 
 The first concrete UI slice stores section navigation (`dungeon` vs `shop`) separately from combat state, which keeps presentational concerns out of the simulation loop.
 Save management stays outside the hot combat loop as well: export/import controls serialize the current playable `GameState` to a JSON file and feed imported saves back through `reset(...)`, so the store remains the single source of truth after deserialization.

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -15,6 +15,10 @@ import {
 } from "../entity";
 import type { DamageElement, EnemyArchetype, Entity, MetaUpgrades, PrestigeUpgrades, StatusEffect, StatusEffectKey } from "../entity";
 import { MAX_PARTY_SIZE } from "../partyProgression";
+import {
+    createEmptyEquipmentProgressionState,
+    createEmptyTalentProgressionState,
+} from "../store/types";
 import type { CombatEvent, GameState } from "../store/types";
 
 export const GAME_TICK_RATE = 20;
@@ -230,6 +234,27 @@ export const createInitialGameState = (overrides?: Partial<GameState>): GameStat
         gameSpeed: overrides?.prestigeUpgrades?.gameSpeed ?? 0,
         xpMultiplier: overrides?.prestigeUpgrades?.xpMultiplier ?? 0,
     };
+    const talentProgression = {
+        ...createEmptyTalentProgressionState(),
+        ...overrides?.talentProgression,
+        unlockedTalentIdsByHeroId: {
+            ...createEmptyTalentProgressionState().unlockedTalentIdsByHeroId,
+            ...(overrides?.talentProgression?.unlockedTalentIdsByHeroId ?? {}),
+        },
+        talentPointsByHeroId: {
+            ...createEmptyTalentProgressionState().talentPointsByHeroId,
+            ...(overrides?.talentProgression?.talentPointsByHeroId ?? {}),
+        },
+    };
+    const equipmentProgression = {
+        ...createEmptyEquipmentProgressionState(),
+        ...overrides?.equipmentProgression,
+        inventoryItemIds: [...(overrides?.equipmentProgression?.inventoryItemIds ?? [])],
+        equippedItemIdsByHeroId: {
+            ...createEmptyEquipmentProgressionState().equippedItemIdsByHeroId,
+            ...(overrides?.equipmentProgression?.equippedItemIdsByHeroId ?? {}),
+        },
+    };
 
     return {
         party: overrides?.party?.map((entity) => hydrateEntity(entity, metaUpgrades, prestigeUpgrades)) ?? [],
@@ -247,6 +272,8 @@ export const createInitialGameState = (overrides?: Partial<GameState>): GameStat
         activeSection: overrides?.activeSection ?? "dungeon",
         heroSouls: new Decimal(overrides?.heroSouls ?? 0),
         prestigeUpgrades,
+        talentProgression,
+        equipmentProgression,
     };
 };
 

--- a/src/game/store/gameStore.tsx
+++ b/src/game/store/gameStore.tsx
@@ -100,6 +100,8 @@ export const useGame = () => {
         activeSection: useGameStore((store) => store.activeSection),
         heroSouls: useGameStore((store) => store.heroSouls),
         prestigeUpgrades: useGameStore((store) => store.prestigeUpgrades),
+        talentProgression: useGameStore((store) => store.talentProgression),
+        equipmentProgression: useGameStore((store) => store.equipmentProgression),
     };
 
     const actions: GameActions = {

--- a/src/game/store/persistence.test.ts
+++ b/src/game/store/persistence.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { createEnemy, createStarterParty } from "@/game/entity";
 import { createInitialGameState } from "@/game/engine/simulation";
 
-import { deserializeGameState, serializeGameState } from "./persistence";
+import { deserializeGameState, GAME_STATE_EXPORT_VERSION, serializeGameState } from "./persistence";
 
 describe("game-state persistence", () => {
     it("roundtrips the playable game state through JSON export and import", () => {
@@ -32,10 +32,27 @@ describe("game-state persistence", () => {
             partyCapacity: 2,
             highestFloorCleared: 7,
             activeSection: "shop",
+            talentProgression: {
+                unlockedTalentIdsByHeroId: {
+                    hero_1: ["blessed-light", "renewing-faith"],
+                },
+                talentPointsByHeroId: {
+                    hero_1: 2,
+                },
+            },
+            equipmentProgression: {
+                inventoryItemIds: ["oak-staff", "saintly-charm"],
+                equippedItemIdsByHeroId: {
+                    hero_1: ["oak-staff"],
+                },
+            },
         });
 
-        const restoredState = deserializeGameState(serializeGameState(exportedState));
+        const serializedState = serializeGameState(exportedState);
+        const payload = JSON.parse(serializedState) as { version: number };
+        const restoredState = deserializeGameState(serializedState);
 
+        expect(payload.version).toBe(GAME_STATE_EXPORT_VERSION);
         expect(restoredState.gold.toString()).toBe("345");
         expect(restoredState.party[0]?.name).toBe("Selene");
         expect(restoredState.party[0]?.currentHp.eq(exportedState.party[0]?.currentHp ?? 0)).toBe(true);
@@ -50,6 +67,8 @@ describe("game-state persistence", () => {
         expect(restoredState.enemies[0]?.name).toBe(exportedState.enemies[0]?.name);
         expect(restoredState.autoFight).toBe(false);
         expect(restoredState.activeSection).toBe("shop");
+        expect(restoredState.talentProgression).toEqual(exportedState.talentProgression);
+        expect(restoredState.equipmentProgression).toEqual(exportedState.equipmentProgression);
     });
 
     it("does not persist transient combat events in exported saves", () => {
@@ -72,18 +91,20 @@ describe("game-state persistence", () => {
         expect(restoredState.combatEvents).toEqual([]);
     });
 
-    it("rehydrates missing combat ratings and scaling stats from older save payloads", () => {
+    it("migrates older versioned saves and defaults missing combat and progression fields", () => {
         const exportedState = createInitialGameState({
             party: createStarterParty("Selene", "Cleric"),
             enemies: [createEnemy(3, "enemy_3")],
         });
 
         const payload = JSON.parse(serializeGameState(exportedState)) as {
+            version: number;
             state: {
                 party: Array<Record<string, unknown>>;
                 enemies: Array<Record<string, unknown>>;
             };
         };
+        payload.version = 1;
 
         delete payload.state.party[0]?.accuracyRating;
         delete payload.state.party[0]?.evasionRating;
@@ -103,6 +124,8 @@ describe("game-state persistence", () => {
         delete payload.state.enemies[0]?.enemyElement;
         delete payload.state.enemies[0]?.guardStacks;
         delete payload.state.enemies[0]?.statusEffects;
+        delete (payload.state as Record<string, unknown>).talentProgression;
+        delete (payload.state as Record<string, unknown>).equipmentProgression;
 
         const restoredState = deserializeGameState(JSON.stringify(payload));
 
@@ -123,6 +146,59 @@ describe("game-state persistence", () => {
         expect(restoredState.enemies[0]?.enemyArchetype).toBe("Bruiser");
         expect(restoredState.enemies[0]?.guardStacks).toBe(0);
         expect(restoredState.enemies[0]?.statusEffects).toEqual([]);
+        expect(restoredState.talentProgression).toEqual({
+            unlockedTalentIdsByHeroId: {},
+            talentPointsByHeroId: {},
+        });
+        expect(restoredState.equipmentProgression).toEqual({
+            inventoryItemIds: [],
+            equippedItemIdsByHeroId: {},
+        });
+    });
+
+    it("restores supported mid-combat encounter state while dropping transient combat events", () => {
+        const party = createStarterParty("Selene", "Cleric");
+        const enemy = createEnemy(3, "enemy_3");
+        party[0].actionProgress = 64;
+        party[0].activeSkill = "Casting Bless";
+        party[0].activeSkillTicks = 8;
+        party[0].guardStacks = 1;
+        enemy.actionProgress = 37;
+        enemy.guardStacks = 1;
+
+        const exportedState = createInitialGameState({
+            party,
+            enemies: [enemy],
+            combatEvents: [
+                {
+                    id: "combat-event-1",
+                    targetId: "enemy_3",
+                    kind: "damage",
+                    text: "-12",
+                    ttlTicks: 8,
+                },
+            ],
+        });
+
+        const restoredState = deserializeGameState(serializeGameState(exportedState));
+
+        expect(restoredState.party[0]?.actionProgress).toBe(64);
+        expect(restoredState.party[0]?.activeSkill).toBe("Casting Bless");
+        expect(restoredState.party[0]?.activeSkillTicks).toBe(8);
+        expect(restoredState.party[0]?.guardStacks).toBe(1);
+        expect(restoredState.enemies[0]?.actionProgress).toBe(37);
+        expect(restoredState.enemies[0]?.guardStacks).toBe(1);
+        expect(restoredState.combatEvents).toEqual([]);
+    });
+
+    it("rejects save payloads from a newer unsupported version", () => {
+        const payload = {
+            version: GAME_STATE_EXPORT_VERSION + 1,
+            savedAt: new Date().toISOString(),
+            state: {},
+        };
+
+        expect(() => deserializeGameState(JSON.stringify(payload))).toThrow(/newer than this build supports/i);
     });
 
     it("rejects malformed save payloads", () => {

--- a/src/game/store/persistence.ts
+++ b/src/game/store/persistence.ts
@@ -1,11 +1,166 @@
 import { createInitialGameState } from "../engine/simulation";
+import {
+    createEmptyEquipmentProgressionState,
+    createEmptyTalentProgressionState,
+} from "./types";
 import type { GameState } from "./types";
 
 export const GAME_STATE_STORAGE_KEY = "idle-dungeon-crawler.game-state";
 export const GAME_STATE_AUTOSAVE_MS = 10_000;
-export const GAME_STATE_EXPORT_VERSION = 1;
+export const GAME_STATE_EXPORT_VERSION = 2;
+const LEGACY_UNVERSIONED_SAVE_VERSION = 0;
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+const hasOwn = <TKey extends string>(value: Record<string, unknown>, key: TKey): value is Record<TKey, unknown> =>
+    Object.prototype.hasOwnProperty.call(value, key);
+const DEFAULT_SAVE_TIMESTAMP = new Date(0).toISOString();
+
+type RawSaveRecord = Record<string, unknown>;
+
+interface SaveEnvelope {
+    version: number;
+    savedAt: string;
+    state: RawSaveRecord;
+}
+
+type SaveMigration = (state: RawSaveRecord) => RawSaveRecord;
+
+const getStringArray = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+
+const getStringArrayRecord = (value: unknown): Record<string, string[]> => {
+    if (!isRecord(value)) {
+        return {};
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).map(([key, entryValue]) => [key, getStringArray(entryValue)]),
+    );
+};
+
+const getNumberRecord = (value: unknown): Record<string, number> => {
+    if (!isRecord(value)) {
+        return {};
+    }
+
+    return Object.entries(value).reduce<Record<string, number>>((accumulator, [key, entryValue]) => {
+        if (typeof entryValue === "number") {
+            accumulator[key] = entryValue;
+        }
+
+        return accumulator;
+    }, {});
+};
+
+const sanitizeTalentProgression = (value: unknown) => {
+    const defaults = createEmptyTalentProgressionState();
+    if (!isRecord(value)) {
+        return defaults;
+    }
+
+    return {
+        unlockedTalentIdsByHeroId: hasOwn(value, "unlockedTalentIdsByHeroId")
+            ? getStringArrayRecord(value.unlockedTalentIdsByHeroId)
+            : defaults.unlockedTalentIdsByHeroId,
+        talentPointsByHeroId: hasOwn(value, "talentPointsByHeroId")
+            ? getNumberRecord(value.talentPointsByHeroId)
+            : defaults.talentPointsByHeroId,
+    };
+};
+
+const sanitizeEquipmentProgression = (value: unknown) => {
+    const defaults = createEmptyEquipmentProgressionState();
+    if (!isRecord(value)) {
+        return defaults;
+    }
+
+    return {
+        inventoryItemIds: hasOwn(value, "inventoryItemIds") ? getStringArray(value.inventoryItemIds) : defaults.inventoryItemIds,
+        equippedItemIdsByHeroId: hasOwn(value, "equippedItemIdsByHeroId")
+            ? getStringArrayRecord(value.equippedItemIdsByHeroId)
+            : defaults.equippedItemIdsByHeroId,
+    };
+};
+
+const sanitizeMigratedEntity = (value: unknown): unknown => {
+    if (!isRecord(value)) {
+        return value;
+    }
+
+    return {
+        ...value,
+        activeSkill: typeof value.activeSkill === "string" ? value.activeSkill : null,
+        activeSkillTicks: typeof value.activeSkillTicks === "number" ? value.activeSkillTicks : 0,
+        actionProgress: typeof value.actionProgress === "number" ? value.actionProgress : 0,
+        guardStacks: typeof value.guardStacks === "number" ? value.guardStacks : 0,
+        statusEffects: Array.isArray(value.statusEffects) ? value.statusEffects : [],
+    };
+};
+
+const sanitizeEntityArray = (value: unknown) => Array.isArray(value) ? value.map(sanitizeMigratedEntity) : value;
+
+const SAVE_MIGRATIONS: Record<number, SaveMigration> = {
+    0: (state) => ({ ...state }),
+    1: (state) => ({
+        ...state,
+        party: sanitizeEntityArray(state.party),
+        enemies: sanitizeEntityArray(state.enemies),
+        combatEvents: [],
+        talentProgression: sanitizeTalentProgression(state.talentProgression),
+        equipmentProgression: sanitizeEquipmentProgression(state.equipmentProgression),
+    }),
+};
+
+const normalizeSaveEnvelope = (value: unknown): SaveEnvelope => {
+    if (!isRecord(value)) {
+        throw new Error("Save data must be a JSON object.");
+    }
+
+    if (hasOwn(value, "state")) {
+        if (!isRecord(value.state)) {
+            throw new Error("Save file is missing required game-state data.");
+        }
+
+        return {
+            version: typeof value.version === "number" ? value.version : 1,
+            savedAt: typeof value.savedAt === "string" ? value.savedAt : DEFAULT_SAVE_TIMESTAMP,
+            state: { ...value.state },
+        };
+    }
+
+    return {
+        version: LEGACY_UNVERSIONED_SAVE_VERSION,
+        savedAt: DEFAULT_SAVE_TIMESTAMP,
+        state: { ...(value as RawSaveRecord) },
+    };
+};
+
+const migrateSaveEnvelope = (envelope: SaveEnvelope): SaveEnvelope => {
+    if (!Number.isInteger(envelope.version) || envelope.version < LEGACY_UNVERSIONED_SAVE_VERSION) {
+        throw new Error("Save file version is invalid.");
+    }
+
+    if (envelope.version > GAME_STATE_EXPORT_VERSION) {
+        throw new Error(`Save file version ${envelope.version} is newer than this build supports.`);
+    }
+
+    let migratedEnvelope = { ...envelope, state: { ...envelope.state } };
+
+    while (migratedEnvelope.version < GAME_STATE_EXPORT_VERSION) {
+        const migration = SAVE_MIGRATIONS[migratedEnvelope.version];
+        if (!migration) {
+            throw new Error(`No migration path from save version ${migratedEnvelope.version}.`);
+        }
+
+        migratedEnvelope = {
+            ...migratedEnvelope,
+            version: migratedEnvelope.version + 1,
+            state: migration(migratedEnvelope.state),
+        };
+    }
+
+    return migratedEnvelope;
+};
 
 const toPartialGameState = (value: unknown): Partial<GameState> => {
     if (!isRecord(value)) {
@@ -80,6 +235,14 @@ const toPartialGameState = (value: unknown): Partial<GameState> => {
         candidate.prestigeUpgrades = prestigeUpgrades;
     }
 
+    if (isRecord(value.talentProgression)) {
+        candidate.talentProgression = sanitizeTalentProgression(value.talentProgression);
+    }
+
+    if (isRecord(value.equipmentProgression)) {
+        candidate.equipmentProgression = sanitizeEquipmentProgression(value.equipmentProgression);
+    }
+
     return candidate;
 };
 
@@ -108,10 +271,10 @@ export const deserializeGameState = (serializedState: string): GameState => {
         throw new Error("Save file is not valid JSON.");
     }
 
-    const rawState = isRecord(parsed) && "state" in parsed ? parsed.state : parsed;
+    const migratedEnvelope = migrateSaveEnvelope(normalizeSaveEnvelope(parsed));
 
     try {
-        return createInitialGameState(toPartialGameState(rawState));
+        return createInitialGameState(toPartialGameState(migratedEnvelope.state));
     } catch (error) {
         if (error instanceof Error) {
             throw error;

--- a/src/game/store/progressionSlice.ts
+++ b/src/game/store/progressionSlice.ts
@@ -18,6 +18,8 @@ export const selectProgressionState = (state: GameState): ProgressionSlice => ({
     highestFloorCleared: state.highestFloorCleared,
     heroSouls: state.heroSouls,
     prestigeUpgrades: state.prestigeUpgrades,
+    talentProgression: state.talentProgression,
+    equipmentProgression: state.equipmentProgression,
 });
 
 export const createProgressionSlice = (

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -39,6 +39,26 @@ export interface PrestigeUpgrades {
     xpMultiplier: number;
 }
 
+export interface TalentProgressionState {
+    unlockedTalentIdsByHeroId: Record<string, string[]>;
+    talentPointsByHeroId: Record<string, number>;
+}
+
+export interface EquipmentProgressionState {
+    inventoryItemIds: string[];
+    equippedItemIdsByHeroId: Record<string, string[]>;
+}
+
+export const createEmptyTalentProgressionState = (): TalentProgressionState => ({
+    unlockedTalentIdsByHeroId: {},
+    talentPointsByHeroId: {},
+});
+
+export const createEmptyEquipmentProgressionState = (): EquipmentProgressionState => ({
+    inventoryItemIds: [],
+    equippedItemIdsByHeroId: {},
+});
+
 export interface ProgressionSlice {
     metaUpgrades: MetaUpgrades;
     partyCapacity: number;
@@ -46,6 +66,8 @@ export interface ProgressionSlice {
     highestFloorCleared: number;
     heroSouls: Decimal;
     prestigeUpgrades: PrestigeUpgrades;
+    talentProgression: TalentProgressionState;
+    equipmentProgression: EquipmentProgressionState;
 }
 
 export interface UiSlice {


### PR DESCRIPTION
Closes #71.

This change adds an explicit versioned migration path for save import/export so the persistence layer can grow safely as layered combat and progression systems continue to add new fields. Before this patch, exported saves carried a version tag, but deserialization mostly ignored it and depended on tolerant partial parsing plus runtime hydration to smooth over missing fields. That was workable for small additive changes, but it left no clear forward path for future systems like talents and equipment, and it meant compatibility logic risked being scattered across unrelated hydration code instead of living in one predictable persistence boundary.

The root problem was that save compatibility was implicit rather than modeled. We had no real envelope normalization, no migration sequencing, no rejection path for unsupported future save versions, and no canonical place to default newly introduced progression fields. This patch introduces a real save envelope flow in `persistence.ts`: incoming JSON is normalized into a save envelope, version-checked, migrated forward step by step, and only then converted into a partial runtime `GameState`. That keeps compatibility behavior local to persistence and makes the migration path obvious when later versions add more fields.

As part of that new schema, the runtime state now includes placeholder progression containers for talents and equipment. They do not add gameplay yet, but they are now part of the canonical save shape so future layered progression work has a stable place to land without reopening the save format every time. Older saves migrate forward with predictable defaults for those progression containers, while current combat encounter state such as action progress, skill banners, guard stacks, and status effects still restores correctly where supported. Transient combat events continue to be dropped on export/import, which preserves the existing browser save ergonomics and avoids persisting purely visual state.

I also updated the architecture notes to document the new versioned migration approach and the save-safe expansion rule. The docs now make it explicit that progression additions must flow through named migration steps instead of relying on best-effort hydration tolerance.

Validation:
- `npm test`
- `npm run lint`
- `npm run build`
