### PR TITLE
[codex] add partial post-victory floor recovery

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
+++ b/docs/ARCHITECTURE/gamedecisions/003-combat-and-atb.md
@@ -26,6 +26,8 @@ If `Autofight` is disabled, the simulation pauses in place: ATB does not fill, a
 
 `Autoadvance` is a separate control. When enabled, the party moves to the next floor after winning an encounter. When disabled, the party immediately starts a fresh encounter on the same floor, allowing the player to continuously farm a target floor without climbing past it.
 
+After a victory, surviving heroes now recover **25% of max HP** before the next encounter begins, whether the player advances or repeats the current floor. This softens long-run attrition without fully resetting encounter pressure. It also makes disabling `Autoadvance` a valid recovery strategy: the player can intentionally repeat a safer floor to regain HP more safely than pushing upward immediately.
+
 * **Base ATB Rate:** `2.0` per tick.
 * **Speed Bonus:** layered `haste` provides a speed bonus calculation: `+ (haste * 0.08)` per tick.
 * **Status Timing:** reusable timed effects decrement once per game tick, while periodic effects such as Burn resolve once per second (`20` ticks).

--- a/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
+++ b/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
@@ -108,6 +108,12 @@ Archetypes bias both stats and behavior:
 **Boss Encounters:**
 Every 10th floor is flagged as a Boss floor. Boss floors spawn exactly **one** enemy regardless of player party size, and that generated boss uses a dedicated `Boss` archetype layered on top of floor scaling. Bosses still receive the softened durability / strength multipliers (`VIT * 2`, `STR * 1.3`), but they also gain broader DEX / INT / WIS reinforcement and a deterministic elemental theme for their phase-two spell pressure. This keeps bosses meaningfully tougher than adjacent floors without recreating the old solo/duo progression wall at Floor `10` or pushing the same pacing problem forward to the later slot milestones.
 
+### Between-Floor Recovery
+
+After a victorious encounter, each **surviving** hero now recovers **25% of max HP** before the next encounter begins. This applies both when advancing and when repeating the current floor with `Autoadvance` disabled.
+
+This keeps attrition relevant while avoiding a hard Cleric-only sustain requirement. It also creates a deliberate low-risk strategy: players can farm or repeat a safer floor to stabilize the party before attempting a harder checkpoint.
+
 ### Party Wipe & Hard Reset
 
 If all party members reach 0 HP, a wipe is triggered. The party is fully healed, but they are forcibly returned to Floor 1, and the collected Gold is reset to `0`. Levels, purchased persistent upgrades, the highest cleared floor, unlocked party slots, and recruited heroes are retained, forming the core "Idle Loop" where the low floors become exponentially faster to clear due to accumulated power.

--- a/src/game/engine/simulation.test.ts
+++ b/src/game/engine/simulation.test.ts
@@ -12,12 +12,14 @@ import {
     getEffectiveCritMultiplier,
     getEncounterSize,
     getActionProgressPerTick,
+    getPostVictoryFloorTransitionState,
     getPhysicalHitChance,
     getPenetrationReduction,
     getSpellHitChance,
     getStatusApplicationChance,
     HEX_DURATION_TICKS,
     isBossFloor,
+    POST_VICTORY_HP_RECOVERY_RATIO,
     REGEN_DURATION_TICKS,
     simulateTick,
 } from "./simulation";
@@ -80,6 +82,45 @@ describe("simulation engine", () => {
         expect(earlyEncounter.map((enemy) => enemy.enemyArchetype)).toEqual(["Skirmisher"]);
         expect(midEncounter.map((enemy) => enemy.enemyArchetype)).toEqual(["Skirmisher", "Caster"]);
         expect(lateEncounter.map((enemy) => enemy.enemyArchetype)).toEqual(["Caster", "Bruiser", "Support"]);
+    });
+
+    it("partially restores surviving heroes after a post-victory floor transition", () => {
+        const warrior = createHero("hero_1", "Brom", "Warrior");
+        warrior.currentHp = warrior.maxHp.div(2);
+        warrior.statusEffects = [
+            {
+                key: "slow",
+                polarity: "debuff",
+                sourceId: "enemy_1",
+                remainingTicks: 5,
+                stacks: 1,
+                maxStacks: 1,
+                potency: 0.2,
+            },
+        ];
+
+        const archer = createHero("hero_2", "Vera", "Archer");
+        archer.currentHp = new Decimal(0);
+
+        const state = createInitialGameState({
+            floor: 4,
+            party: [warrior, archer],
+            enemies: [],
+            combatLog: [],
+        });
+
+        const nextState = getPostVictoryFloorTransitionState(state, 5);
+        const healedWarrior = nextState.party?.[0];
+        const fallenArcher = nextState.party?.[1];
+        const expectedWarriorHp = Decimal.min(
+            warrior.maxHp,
+            warrior.currentHp.plus(warrior.maxHp.times(POST_VICTORY_HP_RECOVERY_RATIO)),
+        );
+
+        expect(nextState.floor).toBe(5);
+        expect(healedWarrior?.currentHp.eq(expectedWarriorHp)).toBe(true);
+        expect(healedWarrior?.statusEffects).toEqual([]);
+        expect(fallenArcher?.currentHp.eq(0)).toBe(true);
     });
 
     it("applies class-template growth packages when heroes level up from combat rewards", () => {

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -65,6 +65,7 @@ export const BLIND_BASE_CHANCE = 0.35;
 export const BLIND_DURATION_TICKS = GAME_TICK_RATE * 3;
 export const BLIND_ACCURACY_REDUCTION = 15;
 export const CLERIC_BLESS_COST = getHeroClassTemplate("Cleric").actionPackage.bless?.cost ?? 25;
+export const POST_VICTORY_HP_RECOVERY_RATIO = 0.25;
 
 const SKILL_BANNER_TICKS = GAME_TICK_RATE;
 const COMBAT_EVENT_TICKS = Math.round(GAME_TICK_RATE * 1.4);
@@ -202,6 +203,18 @@ const clearEncounterState = (entity: Entity): Entity => ({
     statusEffects: [],
 });
 
+const recoverHpAfterVictory = (entity: Entity): Entity => {
+    const cleared = clearEncounterState(entity);
+
+    if (cleared.currentHp.lte(0)) {
+        return cleared;
+    }
+
+    const recoveredHp = cleared.maxHp.times(POST_VICTORY_HP_RECOVERY_RATIO);
+    cleared.currentHp = Decimal.min(cleared.maxHp, cleared.currentHp.plus(recoveredHp));
+    return cleared;
+};
+
 export const recalculateParty = (
     party: Entity[],
     upgrades: MetaUpgrades,
@@ -327,6 +340,29 @@ export const getFloorReplayState = (state: GameState): Partial<GameState> => ({
     party: state.party.map(clearEncounterState),
     enemies: createEncounter(state.floor),
     combatLog: prependCombatMessages(state.combatLog, `Repeating floor ${state.floor}...`),
+    combatEvents: [],
+});
+
+export const getPostVictoryFloorTransitionState = (state: GameState, floor: number): Partial<GameState> => ({
+    floor,
+    party: state.party.map(recoverHpAfterVictory),
+    enemies: createEncounter(floor),
+    combatLog: prependCombatMessages(
+        state.combatLog,
+        `The party recovers ${Math.round(POST_VICTORY_HP_RECOVERY_RATIO * 100)}% HP before the next encounter.`,
+        `Moved to floor ${floor}...`,
+    ),
+    combatEvents: [],
+});
+
+export const getPostVictoryFloorReplayState = (state: GameState): Partial<GameState> => ({
+    party: state.party.map(recoverHpAfterVictory),
+    enemies: createEncounter(state.floor),
+    combatLog: prependCombatMessages(
+        state.combatLog,
+        `The party recovers ${Math.round(POST_VICTORY_HP_RECOVERY_RATIO * 100)}% HP before the next encounter.`,
+        `Repeating floor ${state.floor}...`,
+    ),
     combatEvents: [],
 });
 

--- a/src/game/gameState.integration.test.tsx
+++ b/src/game/gameState.integration.test.tsx
@@ -139,7 +139,7 @@ describe("GameProvider integration", () => {
 
         expect(screen.getByTestId("floor").textContent).toBe("4");
         expect(screen.getByTestId("enemy-count").textContent).toBe("1");
-        expect(screen.getByText(/repeating floor 4/i)).toBeInTheDocument();
+        expect(screen.getByText(/recovers 25% hp/i)).toBeInTheDocument();
     });
 
     it("autosaves the current run to local storage", () => {

--- a/src/game/store/gameStore.test.ts
+++ b/src/game/store/gameStore.test.ts
@@ -73,8 +73,13 @@ describe("createGameStore", () => {
     });
 
     it("restarts the current floor when autoadvance is disabled", () => {
+        const party = createStarterParty("Ayla", "Warrior");
+        const warrior = party[0];
+        const startingHp = warrior.currentHp.div(2);
+        warrior.currentHp = startingHp;
+
         const store = createGameStore({
-            party: createStarterParty("Ayla", "Warrior"),
+            party,
             enemies: [],
             floor: 4,
             autoFight: true,
@@ -90,7 +95,36 @@ describe("createGameStore", () => {
         expect(state.floor).toBe(4);
         expect(state.enemies).toHaveLength(1);
         expect(state.highestFloorCleared).toBe(4);
-        expect(state.combatLog[0]).toMatch(/repeating floor 4/i);
+        expect(state.party[0]?.currentHp.gt(startingHp)).toBe(true);
+        expect(state.party[0]?.currentHp.lt(state.party[0].maxHp)).toBe(true);
+        expect(state.combatLog.some((entry) => /repeating floor 4/i.test(entry))).toBe(true);
+        expect(state.combatLog.some((entry) => /recovers 25% hp/i.test(entry))).toBe(true);
+    });
+
+    it("partially recovers HP after a victory when autoadvance moves to the next floor", () => {
+        const party = createStarterParty("Ayla", "Warrior");
+        const warrior = party[0];
+        const startingHp = warrior.currentHp.div(2);
+        warrior.currentHp = startingHp;
+
+        const store = createGameStore({
+            party,
+            enemies: [],
+            floor: 4,
+            autoFight: true,
+            autoAdvance: true,
+            highestFloorCleared: 2,
+            combatLog: [],
+        });
+
+        store.getState().stepSimulation();
+
+        const state = store.getState();
+
+        expect(state.floor).toBe(5);
+        expect(state.party[0]?.currentHp.gt(startingHp)).toBe(true);
+        expect(state.party[0]?.currentHp.lt(state.party[0].maxHp)).toBe(true);
+        expect(state.combatLog.some((entry) => /moved to floor 5/i.test(entry))).toBe(true);
     });
 
     it("unlocks party slots and recruits duplicate classes after the retuned milestone clears", () => {
@@ -150,6 +184,7 @@ describe("createGameStore", () => {
         party.push(createRecruitHero("Cleric", party));
         party.push(createRecruitHero("Archer", party));
         party.push(createRecruitHero("Warrior", party));
+        party[0].currentHp = party[0].maxHp.div(2);
         party[0].statusEffects = [
             {
                 key: "slow",
@@ -175,6 +210,7 @@ describe("createGameStore", () => {
 
         expect(state.floor).toBe(20);
         expect(state.party).toHaveLength(4);
+        expect(state.party[0]?.currentHp.eq(party[0].maxHp.div(2))).toBe(true);
         expect(state.party[0]?.statusEffects).toEqual([]);
         expect(state.enemies).toHaveLength(1);
         expect(state.enemies[0]?.name.startsWith("Boss:")).toBe(true);

--- a/src/game/store/hotSimulationSlice.ts
+++ b/src/game/store/hotSimulationSlice.ts
@@ -1,6 +1,7 @@
 import {
     GAME_TICK_MS,
-    getFloorReplayState,
+    getPostVictoryFloorReplayState,
+    getPostVictoryFloorTransitionState,
     getFloorTransitionState,
     getInitializedPartyState,
     getPartyWipeState,
@@ -92,9 +93,9 @@ export const createHotSimulationSlice = (
                     }
 
                     if (nextState.autoAdvance) {
-                        nextState = { ...nextState, ...getFloorTransitionState(nextState, nextState.floor + 1) };
+                        nextState = { ...nextState, ...getPostVictoryFloorTransitionState(nextState, nextState.floor + 1) };
                     } else {
-                        nextState = { ...nextState, ...getFloorReplayState(nextState) };
+                        nextState = { ...nextState, ...getPostVictoryFloorReplayState(nextState) };
                     }
                     break;
                 }


### PR DESCRIPTION
Closes #95.

## Summary

This PR adds partial HP recovery after a victorious encounter. Surviving heroes now recover 25% of their max HP before the next encounter begins, whether the run advances to the next floor or repeats the same floor with `Autoadvance` disabled.

## Why this change

Before this PR, floor transitions preserved HP entirely. That meant attrition accumulated across the run, but the shipped hero roster only had real HP sustain on Cleric through `Mend` and `Bless` / `Regen`. In practice, that pushed the game toward an unhealthy conclusion where non-Cleric parties were not just harder, but strategically invalid over meaningful progression because there was no way to stabilize between fights.

It also meant turning off `Autoadvance` could not serve as a valid recovery strategy. Repeating a safer floor still carried the same damaged HP totals into the next encounter, so the player had no low-risk way to recover short of wiping.

## What changed

The PR introduces a bounded post-victory recovery path:

- surviving heroes recover 25% of max HP after a win
- the same rule applies to both advance and replay flows after victory
- dead heroes are not revived by this system
- manual floor navigation still uses the old transition helpers and does not grant free healing
- wipe behavior is unchanged and remains the stronger full reset

Implementation-wise, the recovery logic lives in new post-victory floor-transition helpers in the simulation layer, and the hot simulation slice now uses those helpers only in the victory path.

## Effect on players and strategy

This keeps attrition relevant without fully invalidating Cleric. Cleric still provides better in-fight sustain and lets the party enter the next encounter healthier, but parties are no longer forced into a near-binary “have Cleric or slowly die” sustain model.

It also makes an intended strategy viable: players can disable `Autoadvance` and farm a safer floor to recover gradually before attempting a harder checkpoint. That gives the run a softer recovery loop without turning every floor transition into a full reset.

## Docs

I updated the combat and progression records to describe the new between-floor recovery rule and the repeat-floor recovery strategy.

## Validation

I verified this change with:

- `npx vitest run src/game/engine/simulation.test.ts src/game/store/gameStore.test.ts --coverage=false`
- `npm run build`
- `npm test`
