### PR TITLE
Implement ranked talent progression

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
+++ b/docs/ARCHITECTURE/gamedecisions/004-progression-and-scaling.md
@@ -54,12 +54,13 @@ This keeps progression extensible without creating a wall of new primary stats o
 
 The current shipped baseline is intentionally compact:
 
-* heroes gain talent points at **level 2** and **level 4**
-* each class has **2** fixed talent picks rather than a full tree
+* each class still has **2** fixed talent picks rather than a full tree
+* each talent now has **3** ranks, so the current per-class cap is **6 total talent ranks**
+* heroes gain talent points on each **even level**, currently capping once all class talent ranks are filled (levels `2`, `4`, `6`, `8`, `10`, and `12` for the shipped classes)
 * heroes equip up to **4** items (`weapon`, `armor`, `charm`, `trinket`)
 * equipment now comes from a persistent stash of dropped gear with milestone-gated tiers, simple ranks, and auto-sold overflow
 
-This keeps the first build-differentiation pass readable and easy to tune while still making the layered model playable.
+This keeps the first build-differentiation pass readable and easy to tune while still making the layered model playable deeper into the midgame.
 
 ### Persistent Gold Upgrades
 

--- a/docs/ARCHITECTURE/gamedecisions/009-differentiation-mvp-talents-equipment-and-build-surfacing.md
+++ b/docs/ARCHITECTURE/gamedecisions/009-differentiation-mvp-talents-equipment-and-build-surfacing.md
@@ -43,10 +43,24 @@ These passives are intentionally compact. They are not a second class-template s
 The talent system stays intentionally small:
 
 * each shipped class has **2** fixed talent choices
-* talents are permanent once learned in the current save
-* heroes earn talent points at **level 2** and **level 4**
+* each shipped talent has a fixed **3-rank** cap
+* talents are permanent in the current save, but later points reinforce an existing talent instead of requiring a larger tree
+* heroes earn talent points on each **even level** until their class talent-rank cap is filled
 * talent points are stored per hero in `talentProgression.talentPointsByHeroId`
-* learned talents are stored per hero in `talentProgression.unlockedTalentIdsByHeroId`
+* talent ranks are stored per hero in `talentProgression.talentRanksByHeroId`
+
+The live rank cadence for the shipped classes is therefore:
+
+* `2` talents per class
+* `3` ranks per talent
+* `6` total spendable talent points per hero
+* current point gains at levels `2`, `4`, `6`, `8`, `10`, and `12`
+
+Rank behavior stays intentionally readable:
+
+* **Rank 1** carries the main class-facing identity hook
+* **Ranks 2 and 3** add lighter numeric reinforcement, with small capped riders only where the action package needs it
+* burst, healing, crit, and resource hooks scale more conservatively than broad rating bonuses
 
 The current shipped talents stay focused on combat ratings and existing action packages:
 
@@ -54,7 +68,7 @@ The current shipped talents stay focused on combat ratings and existing action p
 * **Cleric:** `Sunfire`, `Shepherd`
 * **Archer:** `Deadeye`, `Quickdraw`
 
-This is a build-pick MVP, not a branching tree, respec system, or long-form meta progression layer.
+This remains a compact build layer, not a branching tree, respec system, or long-form meta progression layer.
 
 ### Equipment MVP
 
@@ -101,15 +115,15 @@ This keeps build differentiation aligned with the layered-combat direction inste
 
 The MVP uses two complementary surfaces:
 
-* **Party -> character sheet tabs (`Talents` and `Equipment`):** the interaction surface for learning talents and equipping gear
-* **Dungeon roster tooltip and card metadata:** the read surface for combat ratings, passive identity, learned talents, and equipped items
+* **Party -> character sheet tabs (`Talents` and `Equipment`):** the interaction surface for learning or upgrading talents and equipping gear
+* **Dungeon roster tooltip and card metadata:** the read surface for combat ratings, passive identity, ranked talents, and equipped items
 
 The roster tooltip now exposes:
 
 * MVP combat ratings
 * existing derived combat detail (`ACC`, `EVA`, `PAR`, `APEN`, `EPEN`, `TEN`)
 * passive summary
-* learned talents
+* ranked talents (`Rank X / 3`)
 * equipped items
 * resistances and statuses
 

--- a/docs/ARCHITECTURE/gamedecisions/012-build-aware-milestone-balance-baseline.md
+++ b/docs/ARCHITECTURE/gamedecisions/012-build-aware-milestone-balance-baseline.md
@@ -13,7 +13,7 @@ After issue `#95` added **25% post-victory HP recovery** between encounters, thi
 
 The original isolated-floor snapshot is still useful for measuring per-encounter combat pressure, but it no longer fully describes the live climb because party HP and combat momentum now carry across floor transitions.
 
-The goal is still not to declare a new balance pass finished. It is to capture the current live baseline before follow-up issues extend equipment and talent progression or retune slot-gate pacing.
+The goal is still not to declare a new balance pass finished. It is to capture the pre-ranked-talent baseline that justified the next progression pass before follow-up issues extend equipment depth or retune slot-gate pacing.
 
 ## Method
 
@@ -38,7 +38,7 @@ Both lenses compare the same three deterministic build assumptions:
    * all earned current talents learned
    * the strongest currently stocked loadout we can assign while respecting one-item-per-hero ownership
 
-These scenarios intentionally use the current live talent and armory rules rather than hypothetical future unlock systems.
+These scenarios intentionally capture the then-current live talent and armory rules rather than hypothetical future unlock systems.
 
 The recovery-aware checkpoint runs use these ranges:
 
@@ -155,5 +155,5 @@ This baseline directly supports the current follow-up issues:
 
 * `#89` for slot-4 and slot-5 pacing
 * `#90` for staged equipment progression
-* `#91` for ranked talents and longer-lived talent progression
+* `#91`, now implemented, for ranked talents and longer-lived talent progression grounded in this baseline
 * `#92` for Warrior/frontline checkpoint review against the stronger build-aware and recovery-aware baseline

--- a/src/components/EntityRoster.tsx
+++ b/src/components/EntityRoster.tsx
@@ -178,7 +178,7 @@ export const EntityRoster: React.FC<Props> = ({ title, entities, alignRight, cla
                   {!entity.isEnemy ? (
                     <div className="mt-1 flex flex-wrap gap-1">
                       <span className="rounded-full border border-violet-400/25 bg-violet-500/10 px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.18em] text-violet-100">
-                        {buildProfile.talents.length}T
+                        {buildProfile.talents.reduce((total, talent) => total + talent.currentRank, 0)}R
                       </span>
                       <span className="rounded-full border border-sky-400/25 bg-sky-500/10 px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.18em] text-sky-100">
                         {buildProfile.equippedItems.length}G
@@ -297,7 +297,7 @@ export const EntityRoster: React.FC<Props> = ({ title, entities, alignRight, cla
                             <p className="text-slate-400">Talents</p>
                             <p className="font-bold text-slate-50">
                               {buildProfile.talents.length > 0
-                                ? buildProfile.talents.map((talent) => talent.name).join(", ")
+                                ? buildProfile.talents.map((talent) => `${talent.name} R${talent.currentRank}/${talent.maxRank}`).join(", ")
                                 : "No talents learned"}
                             </p>
                           </div>

--- a/src/components/HeroBuildPanel.test.tsx
+++ b/src/components/HeroBuildPanel.test.tsx
@@ -17,7 +17,7 @@ describe("HeroBuildPanel", () => {
                 initialState={{
                     party: createStarterParty("Ayla", "Cleric"),
                     talentProgression: {
-                        unlockedTalentIdsByHeroId: {},
+                        talentRanksByHeroId: {},
                         talentPointsByHeroId: {
                             hero_1: 1,
                         },
@@ -39,7 +39,8 @@ describe("HeroBuildPanel", () => {
         await user.click(within(sunfireCard).getByRole("button", { name: /learn/i }));
 
         expect(screen.getByText(/talent points: 0/i)).toBeInTheDocument();
-        expect(within(sunfireCard).getByRole("button", { name: /learned/i })).toBeDisabled();
+    expect(within(sunfireCard).getByText(/rank 1\/3/i)).toBeInTheDocument();
+    expect(within(sunfireCard).getByRole("button", { name: /upgrade/i })).toBeDisabled();
 
         const weaponSection = screen.getByText(/weapon/i).closest<HTMLElement>("div.rounded-xl");
         if (!weaponSection) {

--- a/src/components/HeroBuildPanel.tsx
+++ b/src/components/HeroBuildPanel.tsx
@@ -8,7 +8,10 @@ import {
     getEquipmentOwnerId,
     getHeroBuildProfile,
     getTalentDefinitionsForClass,
+    getTalentRankForHero,
     getTalentPointsForHero,
+    getTotalTalentRankCapacity,
+    getSpentTalentRanksForHero,
     getSlotLockedReason,
     type EquipmentSlot,
 } from "../game/heroBuilds";
@@ -72,6 +75,8 @@ export const HeroBuildPanel: React.FC = () => {
                             const combatRatings = getCombatRatings(hero, buildState);
                             const talentPoints = getTalentPointsForHero(hero.id, talentProgression);
                             const availableTalents = getTalentDefinitionsForClass(heroClass);
+                            const spentRanks = getSpentTalentRanksForHero(hero.id, talentProgression);
+                            const totalRankCapacity = getTotalTalentRankCapacity(heroClass);
 
                             return (
                                 <div
@@ -114,12 +119,15 @@ export const HeroBuildPanel: React.FC = () => {
                                             <div className="flex items-center justify-between">
                                                 <h4 className="text-xs font-black uppercase tracking-[0.22em] text-slate-300">Talents</h4>
                                                 <span className="text-[10px] uppercase tracking-[0.2em] text-slate-500">
-                                                    {buildProfile.talents.length}/{availableTalents.length} learned
+                                                    {spentRanks}/{totalRankCapacity} ranks
                                                 </span>
                                             </div>
                                             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                                                 {availableTalents.map((talent) => {
-                                                    const isUnlocked = buildProfile.talents.some((unlockedTalent) => unlockedTalent.id === talent.id);
+                                                    const currentRank = getTalentRankForHero(hero.id, talent.id, talentProgression);
+                                                    const maxRank = talent.maxRank ?? 3;
+                                                    const isUnlocked = currentRank > 0;
+                                                    const isMaxed = currentRank >= maxRank;
 
                                                     return (
                                                         <div
@@ -128,16 +136,21 @@ export const HeroBuildPanel: React.FC = () => {
                                                         >
                                                             <div className="flex items-start justify-between gap-3">
                                                                 <div>
-                                                                    <p className="font-bold text-slate-100">{talent.name}</p>
+                                                                    <div className="flex items-center gap-2">
+                                                                        <p className="font-bold text-slate-100">{talent.name}</p>
+                                                                        <span className="rounded-full border border-slate-600/70 bg-slate-950/70 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-slate-300">
+                                                                            Rank {currentRank}/{maxRank}
+                                                                        </span>
+                                                                    </div>
                                                                     <p className="mt-1 text-xs text-slate-400">{talent.description}</p>
                                                                 </div>
                                                                 <Button
                                                                     size="sm"
                                                                     variant={isUnlocked ? "secondary" : "upgrade"}
-                                                                    disabled={isUnlocked || talentPoints <= 0}
+                                                                    disabled={isMaxed || talentPoints <= 0}
                                                                     onClick={() => unlockTalent(hero.id, talent.id)}
                                                                 >
-                                                                    {isUnlocked ? "Learned" : "Learn"}
+                                                                    {isMaxed ? "Maxed" : currentRank === 0 ? "Learn" : "Upgrade"}
                                                                 </Button>
                                                             </div>
                                                         </div>

--- a/src/components/PartyView.test.tsx
+++ b/src/components/PartyView.test.tsx
@@ -73,7 +73,7 @@ describe("PartyView", () => {
                 initialState={{
                     party: createStarterParty("Ayla", "Cleric"),
                     talentProgression: {
-                        unlockedTalentIdsByHeroId: {},
+                        talentRanksByHeroId: {},
                         talentPointsByHeroId: { hero_1: 1 },
                     },
                 }}
@@ -92,6 +92,7 @@ describe("PartyView", () => {
         await user.click(learnButtons[0]);
 
         expect(screen.getByText(/0 pts/i)).toBeInTheDocument();
+    expect(screen.getByText(/rank 1\/3/i)).toBeInTheDocument();
     });
 
     it("switches to equipment panel and shows all four gear slots", async () => {

--- a/src/components/PartyView.tsx
+++ b/src/components/PartyView.tsx
@@ -21,7 +21,10 @@ import {
     getHeroBuildProfile,
     getSlotLockedReason,
     getTalentDefinitionsForClass,
+    getTalentRankForHero,
     getTalentPointsForHero,
+    getTotalTalentRankCapacity,
+    getSpentTalentRanksForHero,
     getUnequippedInventoryItems,
     type EquipmentSlot,
 } from "../game/heroBuilds";
@@ -247,12 +250,14 @@ const TalentsPanel: React.FC<{
         equipmentProgression,
     });
     const talentPoints = getTalentPointsForHero(hero.id, talentProgression);
+    const spentRanks = getSpentTalentRanksForHero(hero.id, talentProgression);
+    const totalRankCapacity = getTotalTalentRankCapacity(heroClass);
 
     return (
         <div className="space-y-3">
             <div className="flex items-center justify-between">
                 <span className="text-[10px] font-black uppercase tracking-[0.22em] text-slate-500">
-                    {buildProfile.talents.length}/{availableTalents.length} learned
+                    {spentRanks}/{totalRankCapacity} ranks
                 </span>
                 <span className="rounded-full border border-violet-400/30 bg-violet-950/30 px-3 py-0.5 text-xs font-black uppercase tracking-wider text-violet-200">
                     {talentPoints} pts
@@ -261,7 +266,10 @@ const TalentsPanel: React.FC<{
 
             <div className="space-y-2">
                 {availableTalents.map((talent) => {
-                    const isUnlocked = buildProfile.talents.some((t) => t.id === talent.id);
+                    const currentRank = getTalentRankForHero(hero.id, talent.id, talentProgression);
+                    const maxRank = talent.maxRank ?? 3;
+                    const isUnlocked = currentRank > 0;
+                    const isMaxed = currentRank >= maxRank;
                     return (
                         <div
                             key={talent.id}
@@ -273,7 +281,12 @@ const TalentsPanel: React.FC<{
                         >
                             <div className="flex items-start justify-between gap-2">
                                 <div className="min-w-0">
-                                    <p className="text-sm font-bold text-slate-100">{talent.name}</p>
+                                    <div className="flex items-center gap-2">
+                                        <p className="text-sm font-bold text-slate-100">{talent.name}</p>
+                                        <span className="rounded-full border border-slate-600/70 bg-slate-950/70 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-slate-300">
+                                            Rank {currentRank}/{maxRank}
+                                        </span>
+                                    </div>
                                     <p className="mt-0.5 text-xs text-slate-400">
                                         {talent.description}
                                     </p>
@@ -281,11 +294,11 @@ const TalentsPanel: React.FC<{
                                 <Button
                                     size="sm"
                                     variant={isUnlocked ? "secondary" : "upgrade"}
-                                    disabled={isUnlocked || talentPoints <= 0}
+                                    disabled={isMaxed || talentPoints <= 0}
                                     onClick={() => unlockTalent(hero.id, talent.id)}
                                     className="shrink-0"
                                 >
-                                    {isUnlocked ? "✓" : "Learn"}
+                                    {isMaxed ? "Maxed" : currentRank === 0 ? "Learn" : "Upgrade"}
                                 </Button>
                             </div>
                         </div>

--- a/src/game/engine/balanceSnapshot.ts
+++ b/src/game/engine/balanceSnapshot.ts
@@ -87,6 +87,7 @@ export interface MilestoneWinRateSnapshot {
 
 export interface SnapshotHeroBuildConfig {
     talentIds?: string[];
+    talentRanks?: Record<string, number>;
     equippedItemIds?: string[];
 }
 
@@ -206,7 +207,7 @@ const createBuildProgression = (
         return {};
     }
 
-    const unlockedTalentIdsByHeroId: Record<string, string[]> = {};
+    const talentRanksByHeroId: Record<string, Record<string, number>> = {};
     const talentPointsByHeroId: Record<string, number> = {};
     const equippedItemInstanceIdsByHeroId: Record<string, string[]> = {};
     const inventoryItems: EquipmentItemInstance[] = [];
@@ -218,11 +219,17 @@ const createBuildProgression = (
             return;
         }
 
-        const talentIds = [...new Set(buildConfig.talentIds ?? [])];
+        const talentRanks: Record<string, number> = buildConfig.talentRanks
+            ? Object.fromEntries(
+                Object.entries(buildConfig.talentRanks)
+                    .map(([talentId, rank]) => [talentId, Math.max(0, Math.floor(rank))])
+                        .filter((entry): entry is [string, number] => typeof entry[1] === "number" && entry[1] > 0),
+            )
+            : Object.fromEntries([...new Set(buildConfig.talentIds ?? [])].map((talentId) => [talentId, 1]));
         const equippedItemIds = [...new Set(buildConfig.equippedItemIds ?? [])];
         const equippedItems = createEquipmentInstancesFromDefinitionIds(equippedItemIds, `${hero.id}-item`);
 
-        unlockedTalentIdsByHeroId[hero.id] = talentIds;
+        talentRanksByHeroId[hero.id] = talentRanks;
         talentPointsByHeroId[hero.id] = 0;
         equippedItemInstanceIdsByHeroId[hero.id] = equippedItems.map((item: EquipmentItemInstance) => item.instanceId);
         inventoryItems.push(...equippedItems);
@@ -231,7 +238,7 @@ const createBuildProgression = (
 
     return {
         talentProgression: {
-            unlockedTalentIdsByHeroId,
+            talentRanksByHeroId,
             talentPointsByHeroId,
         },
         equipmentProgression: {

--- a/src/game/engine/simulation.ts
+++ b/src/game/engine/simulation.ts
@@ -268,9 +268,9 @@ export const createInitialGameState = (overrides?: Partial<GameState>): GameStat
     const syncedTalentProgression = synchronizeTalentProgression(rawParty, {
         ...createEmptyTalentProgressionState(),
         ...overrides?.talentProgression,
-        unlockedTalentIdsByHeroId: {
-            ...createEmptyTalentProgressionState().unlockedTalentIdsByHeroId,
-            ...(overrides?.talentProgression?.unlockedTalentIdsByHeroId ?? {}),
+        talentRanksByHeroId: {
+            ...createEmptyTalentProgressionState().talentRanksByHeroId,
+            ...(overrides?.talentProgression?.talentRanksByHeroId ?? {}),
         },
         talentPointsByHeroId: {
             ...createEmptyTalentProgressionState().talentPointsByHeroId,
@@ -875,8 +875,8 @@ export const simulateTick = (state: GameState, randomSource: SimulationRandomSou
         combatEvents: state.combatEvents.map((event) => ({ ...event })),
         metaUpgrades: { ...state.metaUpgrades },
         talentProgression: {
-            unlockedTalentIdsByHeroId: Object.fromEntries(
-                Object.entries(state.talentProgression.unlockedTalentIdsByHeroId).map(([heroId, talentIds]) => [heroId, [...talentIds]]),
+            talentRanksByHeroId: Object.fromEntries(
+                Object.entries(state.talentProgression.talentRanksByHeroId).map(([heroId, talentRanks]) => [heroId, { ...talentRanks }]),
             ),
             talentPointsByHeroId: { ...state.talentProgression.talentPointsByHeroId },
         },

--- a/src/game/entity.test.ts
+++ b/src/game/entity.test.ts
@@ -97,8 +97,11 @@ describe("entity model", () => {
         const boostedCleric = createHero("hero_1", "Ayla", "Cleric");
         const buildState = {
             talentProgression: {
-                unlockedTalentIdsByHeroId: {
-                    hero_1: ["cleric-sunfire", "cleric-shepherd"],
+                talentRanksByHeroId: {
+                    hero_1: {
+                        "cleric-sunfire": 3,
+                        "cleric-shepherd": 2,
+                    },
                 },
                 talentPointsByHeroId: {
                     hero_1: 0,
@@ -121,6 +124,7 @@ describe("entity model", () => {
         expect(boostedRatings.potency).toBeGreaterThan(baselineRatings.potency);
         expect(boostedCleric.magicDamage.gt(baselineCleric.magicDamage)).toBe(true);
         expect(boostedCleric.maxResource.gt(baselineCleric.maxResource)).toBe(true);
+        expect(boostedRatings.spellPower - baselineRatings.spellPower).toBeGreaterThanOrEqual(10);
     });
 
     it("creates tougher boss enemies on every tenth floor with the softened boss multipliers", () => {

--- a/src/game/heroBuilds.test.ts
+++ b/src/game/heroBuilds.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { createStarterParty, getCombatRatings, recalculateEntity } from "@/game/entity";
+
+import {
+    getEarnedTalentPointTotal,
+    getSpentTalentRanksForHero,
+    synchronizeTalentProgression,
+} from "./heroBuilds";
+
+describe("hero build helpers", () => {
+    it("extends talent point awards across even levels until total rank capacity is filled", () => {
+        expect(getEarnedTalentPointTotal("Cleric", 1)).toBe(0);
+        expect(getEarnedTalentPointTotal("Cleric", 2)).toBe(1);
+        expect(getEarnedTalentPointTotal("Cleric", 4)).toBe(2);
+        expect(getEarnedTalentPointTotal("Cleric", 6)).toBe(3);
+        expect(getEarnedTalentPointTotal("Cleric", 12)).toBe(6);
+        expect(getEarnedTalentPointTotal("Cleric", 20)).toBe(6);
+    });
+
+    it("keeps remaining points in sync with spent talent ranks", () => {
+        const party = createStarterParty("Ayla", "Cleric");
+        party[0].level = 8;
+
+        const talentProgression = synchronizeTalentProgression(party, {
+            talentRanksByHeroId: {
+                hero_1: {
+                    "cleric-sunfire": 2,
+                    "cleric-shepherd": 1,
+                },
+            },
+            talentPointsByHeroId: {
+                hero_1: 0,
+            },
+        });
+
+        expect(getSpentTalentRanksForHero("hero_1", talentProgression)).toBe(3);
+        expect(talentProgression.talentPointsByHeroId.hero_1).toBe(1);
+    });
+
+    it("applies stronger build bonuses at higher talent ranks", () => {
+        const [baselineCleric] = createStarterParty("Ayla", "Cleric");
+        const [rankedCleric] = createStarterParty("Ayla", "Cleric");
+
+        const rankOneProgression = synchronizeTalentProgression([rankedCleric], {
+            talentRanksByHeroId: {
+                hero_1: {
+                    "cleric-sunfire": 1,
+                },
+            },
+            talentPointsByHeroId: {
+                hero_1: 0,
+            },
+        });
+
+        const rankThreeProgression = synchronizeTalentProgression([rankedCleric], {
+            talentRanksByHeroId: {
+                hero_1: {
+                    "cleric-sunfire": 3,
+                },
+            },
+            talentPointsByHeroId: {
+                hero_1: 0,
+            },
+        });
+
+        const baselineRatings = getCombatRatings(baselineCleric);
+
+        recalculateEntity(rankedCleric, undefined, undefined, {
+            talentProgression: rankOneProgression,
+            equipmentProgression: {
+                inventoryItems: [],
+                equippedItemInstanceIdsByHeroId: { hero_1: [] },
+                highestUnlockedEquipmentTier: 1,
+                inventoryCapacityLevel: 0,
+                inventoryCapacity: 12,
+                nextInstanceSequence: 1,
+            },
+        });
+
+        const rankOneRatings = getCombatRatings(rankedCleric, {
+            talentProgression: rankOneProgression,
+            equipmentProgression: {
+                inventoryItems: [],
+                equippedItemInstanceIdsByHeroId: { hero_1: [] },
+                highestUnlockedEquipmentTier: 1,
+                inventoryCapacityLevel: 0,
+                inventoryCapacity: 12,
+                nextInstanceSequence: 1,
+            },
+        });
+
+        recalculateEntity(rankedCleric, undefined, undefined, {
+            talentProgression: rankThreeProgression,
+            equipmentProgression: {
+                inventoryItems: [],
+                equippedItemInstanceIdsByHeroId: { hero_1: [] },
+                highestUnlockedEquipmentTier: 1,
+                inventoryCapacityLevel: 0,
+                inventoryCapacity: 12,
+                nextInstanceSequence: 1,
+            },
+        });
+
+        const rankThreeRatings = getCombatRatings(rankedCleric, {
+            talentProgression: rankThreeProgression,
+            equipmentProgression: {
+                inventoryItems: [],
+                equippedItemInstanceIdsByHeroId: { hero_1: [] },
+                highestUnlockedEquipmentTier: 1,
+                inventoryCapacityLevel: 0,
+                inventoryCapacity: 12,
+                nextInstanceSequence: 1,
+            },
+        });
+
+        expect(rankOneRatings.spellPower).toBeGreaterThan(baselineRatings.spellPower);
+        expect(rankThreeRatings.spellPower).toBeGreaterThan(rankOneRatings.spellPower);
+        expect(rankThreeRatings.potency).toBeGreaterThan(rankOneRatings.potency);
+    });
+});

--- a/src/game/heroBuilds.ts
+++ b/src/game/heroBuilds.ts
@@ -36,6 +36,13 @@ export interface TalentDefinition {
     name: string;
     description: string;
     effects: HeroBuildEffects;
+    maxRank?: number;
+    perRankEffects?: HeroBuildEffects;
+}
+
+export interface RankedTalentDefinition extends Omit<TalentDefinition, "maxRank"> {
+    maxRank: number;
+    currentRank: number;
 }
 
 export interface EquipmentItemDefinition {
@@ -66,7 +73,7 @@ export interface HeroBuildState {
 
 export interface HeroBuildProfile {
     passive: ClassPassiveDefinition | null;
-    talents: TalentDefinition[];
+    talents: RankedTalentDefinition[];
     equippedItems: ResolvedEquipmentItem[];
     effects: Required<Omit<HeroBuildEffects, "ratingBonuses">> & {
         ratingBonuses: Partial<Record<HeroCombatRating, number>>;
@@ -85,6 +92,7 @@ const BUILD_EFFECT_KEYS: Array<keyof Omit<HeroBuildEffects, "ratingBonuses">> = 
     "resourceOnTakeDamageBonus",
     "maxResourceFlatBonus",
 ];
+const DEFAULT_TALENT_MAX_RANK = 3;
 
 export const EQUIPMENT_SLOT_LABELS: Record<EquipmentSlot, string> = {
     weapon: "Weapon",
@@ -135,6 +143,10 @@ export const TALENT_DEFINITIONS: TalentDefinition[] = [
         effects: {
             ratingBonuses: { guard: 4, resolve: 2 },
         },
+        maxRank: DEFAULT_TALENT_MAX_RANK,
+        perRankEffects: {
+            ratingBonuses: { guard: 2, resolve: 1 },
+        },
     },
     {
         id: "warrior-rampage",
@@ -145,6 +157,11 @@ export const TALENT_DEFINITIONS: TalentDefinition[] = [
             specialAttackCostDelta: -5,
             specialAttackDamageMultiplierBonus: 0.35,
         },
+        maxRank: DEFAULT_TALENT_MAX_RANK,
+        perRankEffects: {
+            specialAttackCostDelta: -1,
+            specialAttackDamageMultiplierBonus: 0.12,
+        },
     },
     {
         id: "cleric-sunfire",
@@ -153,6 +170,10 @@ export const TALENT_DEFINITIONS: TalentDefinition[] = [
         description: "Lean harder into radiant pressure with stronger spell output and potency.",
         effects: {
             ratingBonuses: { spellPower: 4, potency: 3 },
+        },
+        maxRank: DEFAULT_TALENT_MAX_RANK,
+        perRankEffects: {
+            ratingBonuses: { spellPower: 2, potency: 1 },
         },
     },
     {
@@ -164,6 +185,11 @@ export const TALENT_DEFINITIONS: TalentDefinition[] = [
             healMultiplierBonus: 0.35,
             blessRegenMultiplierBonus: 0.05,
         },
+        maxRank: DEFAULT_TALENT_MAX_RANK,
+        perRankEffects: {
+            healMultiplierBonus: 0.1,
+            blessRegenMultiplierBonus: 0.03,
+        },
     },
     {
         id: "archer-deadeye",
@@ -172,6 +198,10 @@ export const TALENT_DEFINITIONS: TalentDefinition[] = [
         description: "Trade discipline for deadlier crit pressure and cleaner shots.",
         effects: {
             ratingBonuses: { precision: 4, crit: 4 },
+        },
+        maxRank: DEFAULT_TALENT_MAX_RANK,
+        perRankEffects: {
+            ratingBonuses: { precision: 2, crit: 1 },
         },
     },
     {
@@ -182,6 +212,11 @@ export const TALENT_DEFINITIONS: TalentDefinition[] = [
         effects: {
             ratingBonuses: { haste: 3 },
             specialAttackDamageMultiplierBonus: 0.2,
+        },
+        maxRank: DEFAULT_TALENT_MAX_RANK,
+        perRankEffects: {
+            ratingBonuses: { haste: 1 },
+            specialAttackDamageMultiplierBonus: 0.08,
         },
     },
 ];
@@ -447,8 +482,13 @@ export const getClassPassive = (heroClass: HeroClass) => CLASS_PASSIVES[heroClas
 
 export const getTalentDefinition = (talentId: string) => TALENT_LOOKUP.get(talentId) ?? null;
 
+export const getTalentMaxRank = (talent: Pick<TalentDefinition, "maxRank">) => Math.max(1, talent.maxRank ?? DEFAULT_TALENT_MAX_RANK);
+
 export const getTalentDefinitionsForClass = (heroClass: HeroClass) =>
     TALENT_DEFINITIONS.filter((talent) => talent.heroClass === heroClass);
+
+export const getTotalTalentRankCapacity = (heroClass: HeroClass) =>
+    getTalentDefinitionsForClass(heroClass).reduce((total, talent) => total + getTalentMaxRank(talent), 0);
 
 export const getEquipmentDefinition = (definitionId: string) => EQUIPMENT_LOOKUP.get(definitionId) ?? null;
 
@@ -610,8 +650,22 @@ export const getAvailableInventoryItemsForHero = (
 export const getTalentPointsForHero = (heroId: string, talentProgression: TalentProgressionState) =>
     talentProgression.talentPointsByHeroId[heroId] ?? 0;
 
+export const getHeroTalentRanks = (heroId: string, talentProgression: TalentProgressionState) =>
+    talentProgression.talentRanksByHeroId[heroId] ?? {};
+
+export const getTalentRankForHero = (heroId: string, talentId: string, talentProgression: TalentProgressionState) =>
+    getHeroTalentRanks(heroId, talentProgression)[talentId] ?? 0;
+
 export const getHeroUnlockedTalentIds = (heroId: string, talentProgression: TalentProgressionState) =>
-    talentProgression.unlockedTalentIdsByHeroId[heroId] ?? [];
+    Object.entries(getHeroTalentRanks(heroId, talentProgression))
+        .filter(([, rank]) => rank > 0)
+        .map(([talentId]) => talentId);
+
+export const getSpentTalentRanksForHero = (heroId: string, talentProgression: TalentProgressionState) =>
+    Object.values(getHeroTalentRanks(heroId, talentProgression)).reduce((total, rank) => total + rank, 0);
+
+export const getTalentEffectsForRank = (talent: TalentDefinition, rank: number): HeroBuildEffects =>
+    getMergedEffects(talent.effects, scaleBuildEffects(talent.perRankEffects, Math.max(0, rank - 1)));
 
 export const getHeroUnlockedTalents = (
     hero: Pick<Entity, "id" | "class" | "isEnemy">,
@@ -621,14 +675,27 @@ export const getHeroUnlockedTalents = (
         return [];
     }
     const heroClass = hero.class;
+    const heroTalentRanks = getHeroTalentRanks(hero.id, talentProgression);
 
-    return getHeroUnlockedTalentIds(hero.id, talentProgression)
-        .map((talentId) => getTalentDefinition(talentId))
-        .filter((talent): talent is TalentDefinition => Boolean(talent && talent.heroClass === heroClass));
+    return Object.entries(heroTalentRanks)
+        .map(([talentId, rank]) => {
+            const talent = getTalentDefinition(talentId);
+            if (!talent || talent.heroClass !== heroClass || rank <= 0) {
+                return null;
+            }
+
+            return {
+                ...talent,
+                maxRank: getTalentMaxRank(talent),
+                currentRank: Math.min(getTalentMaxRank(talent), rank),
+                effects: getTalentEffectsForRank(talent, rank),
+            } satisfies RankedTalentDefinition;
+        })
+        .filter((talent): talent is RankedTalentDefinition => Boolean(talent));
 };
 
 export const getEarnedTalentPointTotal = (heroClass: HeroClass, level: number) =>
-    Math.min(getTalentDefinitionsForClass(heroClass).length, Math.floor(level / 2));
+    Math.min(getTotalTalentRankCapacity(heroClass), Math.floor(level / 2));
 
 export const getHeroBuildProfile = (
     hero: Pick<Entity, "id" | "class" | "isEnemy">,
@@ -679,7 +746,7 @@ export const synchronizeTalentProgression = (
     party: Array<Pick<Entity, "id" | "class" | "level" | "isEnemy">>,
     talentProgression: TalentProgressionState,
 ): TalentProgressionState => {
-    const nextUnlocked: Record<string, string[]> = {};
+    const nextTalentRanks: Record<string, Record<string, number>> = {};
     const nextPoints: Record<string, number> = {};
 
     party.forEach((hero) => {
@@ -688,18 +755,27 @@ export const synchronizeTalentProgression = (
         }
 
         const heroClass = hero.class;
-        const availableTalentIds = new Set(getTalentDefinitionsForClass(heroClass).map((talent) => talent.id));
-        const validUnlockedIds = dedupeStrings(getHeroUnlockedTalentIds(hero.id, talentProgression))
-            .filter((talentId) => availableTalentIds.has(talentId));
-        const minimumRemainingPoints = Math.max(0, getEarnedTalentPointTotal(heroClass, hero.level) - validUnlockedIds.length);
+        const availableTalents = new Map(getTalentDefinitionsForClass(heroClass).map((talent) => [talent.id, talent]));
+        const validTalentRanks: Record<string, number> = Object.fromEntries(
+            Object.entries(getHeroTalentRanks(hero.id, talentProgression))
+                .filter(([talentId]) => availableTalents.has(talentId))
+                .map(([talentId, rank]) => {
+                    const talent = availableTalents.get(talentId)!;
+                    return [talentId, Math.max(0, Math.min(getTalentMaxRank(talent), Math.floor(rank)))];
+                })
+                .filter((entry): entry is [string, number] => typeof entry[1] === "number" && entry[1] > 0),
+        );
+        const spentRanks = Object.values(validTalentRanks).reduce<number>((total, rank) => total + rank, 0);
+        const minimumRemainingPoints = Math.max(0, getEarnedTalentPointTotal(heroClass, hero.level) - spentRanks);
         const existingPoints = getTalentPointsForHero(hero.id, talentProgression);
+        const maximumRemainingPoints = Math.max(0, getTotalTalentRankCapacity(heroClass) - spentRanks);
 
-        nextUnlocked[hero.id] = validUnlockedIds;
-        nextPoints[hero.id] = Math.max(existingPoints, minimumRemainingPoints);
+        nextTalentRanks[hero.id] = validTalentRanks;
+        nextPoints[hero.id] = Math.max(0, Math.min(Math.max(existingPoints, minimumRemainingPoints), maximumRemainingPoints));
     });
 
     return {
-        unlockedTalentIdsByHeroId: nextUnlocked,
+        talentRanksByHeroId: nextTalentRanks,
         talentPointsByHeroId: nextPoints,
     };
 };

--- a/src/game/store/gameStore.test.ts
+++ b/src/game/store/gameStore.test.ts
@@ -239,9 +239,9 @@ describe("createGameStore", () => {
         const store = createGameStore({
             party: createStarterParty("Ayla", "Cleric"),
             talentProgression: {
-                unlockedTalentIdsByHeroId: {},
+                talentRanksByHeroId: {},
                 talentPointsByHeroId: {
-                    hero_1: 1,
+                    hero_1: 3,
                 },
             },
             equipmentProgression: createLegacyEquipmentProgression(["sunlit-censer"], {}),
@@ -252,9 +252,20 @@ describe("createGameStore", () => {
         store.getState().unlockTalent("hero_1", "cleric-sunfire");
         let state = store.getState();
 
-        expect(state.talentProgression.unlockedTalentIdsByHeroId.hero_1).toEqual(["cleric-sunfire"]);
-        expect(state.talentProgression.talentPointsByHeroId.hero_1).toBe(0);
+        expect(state.talentProgression.talentRanksByHeroId.hero_1).toEqual({ "cleric-sunfire": 1 });
+        expect(state.talentProgression.talentPointsByHeroId.hero_1).toBe(2);
         expect(state.party[0]?.magicDamage.gt(startingMagicDamage ?? 0)).toBe(true);
+
+        const rankOneMagicDamage = state.party[0]?.magicDamage;
+
+        store.getState().unlockTalent("hero_1", "cleric-sunfire");
+        store.getState().unlockTalent("hero_1", "cleric-sunfire");
+        store.getState().unlockTalent("hero_1", "cleric-sunfire");
+        state = store.getState();
+
+        expect(state.talentProgression.talentRanksByHeroId.hero_1).toEqual({ "cleric-sunfire": 3 });
+        expect(state.talentProgression.talentPointsByHeroId.hero_1).toBe(0);
+        expect(state.party[0]?.magicDamage.gt(rankOneMagicDamage ?? 0)).toBe(true);
 
         store.getState().equipItem("hero_1", "sunlit-censer");
         state = store.getState();

--- a/src/game/store/persistence.test.ts
+++ b/src/game/store/persistence.test.ts
@@ -34,8 +34,11 @@ describe("game-state persistence", () => {
             highestFloorCleared: 7,
             activeSection: "shop",
             talentProgression: {
-                unlockedTalentIdsByHeroId: {
-                    hero_1: ["blessed-light", "renewing-faith"],
+                talentRanksByHeroId: {
+                    hero_1: {
+                        "cleric-sunfire": 2,
+                        "cleric-shepherd": 1,
+                    },
                 },
                 talentPointsByHeroId: {
                     hero_1: 2,
@@ -148,8 +151,8 @@ describe("game-state persistence", () => {
         expect(restoredState.enemies[0]?.guardStacks).toBe(0);
         expect(restoredState.enemies[0]?.statusEffects).toEqual([]);
         expect(restoredState.talentProgression).toEqual({
-            unlockedTalentIdsByHeroId: {
-                hero_1: [],
+            talentRanksByHeroId: {
+                hero_1: {},
             },
             talentPointsByHeroId: {
                 hero_1: 0,
@@ -214,5 +217,38 @@ describe("game-state persistence", () => {
 
     it("rejects malformed save payloads", () => {
         expect(() => deserializeGameState("[]")).toThrow(/json object/i);
+    });
+
+    it("migrates legacy learned-talent arrays into rank-1 talent maps", () => {
+        const payload = {
+            version: 3,
+            savedAt: new Date().toISOString(),
+            state: {
+                party: createStarterParty("Selene", "Cleric"),
+                enemies: [],
+                talentProgression: {
+                    unlockedTalentIdsByHeroId: {
+                        hero_1: ["cleric-sunfire", "cleric-shepherd"],
+                    },
+                    talentPointsByHeroId: {
+                        hero_1: 1,
+                    },
+                },
+            },
+        };
+
+        const restoredState = deserializeGameState(JSON.stringify(payload));
+
+        expect(restoredState.talentProgression).toEqual({
+            talentRanksByHeroId: {
+                hero_1: {
+                    "cleric-sunfire": 1,
+                    "cleric-shepherd": 1,
+                },
+            },
+            talentPointsByHeroId: {
+                hero_1: 1,
+            },
+        });
     });
 });

--- a/src/game/store/persistence.ts
+++ b/src/game/store/persistence.ts
@@ -8,7 +8,7 @@ import type { GameState } from "./types";
 
 export const GAME_STATE_STORAGE_KEY = "idle-dungeon-crawler.game-state";
 export const GAME_STATE_AUTOSAVE_MS = 10_000;
-export const GAME_STATE_EXPORT_VERSION = 3;
+export const GAME_STATE_EXPORT_VERSION = 4;
 const LEGACY_UNVERSIONED_SAVE_VERSION = 0;
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
@@ -53,6 +53,16 @@ const getNumberRecord = (value: unknown): Record<string, number> => {
     }, {});
 };
 
+const getNestedNumberRecord = (value: unknown): Record<string, Record<string, number>> => {
+    if (!isRecord(value)) {
+        return {};
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).map(([key, entryValue]) => [key, getNumberRecord(entryValue)]),
+    );
+};
+
 const getInventoryItemArray = (value: unknown) => {
     if (!Array.isArray(value)) {
         return [];
@@ -85,10 +95,21 @@ const sanitizeTalentProgression = (value: unknown) => {
         return defaults;
     }
 
+    const legacyUnlockedTalentIdsByHeroId = hasOwn(value, "unlockedTalentIdsByHeroId")
+        ? value.unlockedTalentIdsByHeroId
+        : undefined;
+
     return {
-        unlockedTalentIdsByHeroId: hasOwn(value, "unlockedTalentIdsByHeroId")
-            ? getStringArrayRecord(value.unlockedTalentIdsByHeroId)
-            : defaults.unlockedTalentIdsByHeroId,
+        talentRanksByHeroId: hasOwn(value, "talentRanksByHeroId")
+            ? getNestedNumberRecord(value.talentRanksByHeroId)
+            : legacyUnlockedTalentIdsByHeroId
+                ? Object.fromEntries(
+                    Object.entries(getStringArrayRecord(legacyUnlockedTalentIdsByHeroId)).map(([heroId, talentIds]) => [
+                        heroId,
+                        Object.fromEntries(talentIds.map((talentId) => [talentId, 1])),
+                    ]),
+                )
+                : defaults.talentRanksByHeroId,
         talentPointsByHeroId: hasOwn(value, "talentPointsByHeroId")
             ? getNumberRecord(value.talentPointsByHeroId)
             : defaults.talentPointsByHeroId,
@@ -161,6 +182,10 @@ const SAVE_MIGRATIONS: Record<number, SaveMigration> = {
     2: (state) => ({
         ...state,
         equipmentProgression: sanitizeEquipmentProgression(state.equipmentProgression),
+    }),
+    3: (state) => ({
+        ...state,
+        talentProgression: sanitizeTalentProgression(state.talentProgression),
     }),
 };
 

--- a/src/game/store/progressionSlice.ts
+++ b/src/game/store/progressionSlice.ts
@@ -185,16 +185,22 @@ export const createProgressionSlice = (
                     return {};
                 }
 
-                const unlockedTalentIds = state.talentProgression.unlockedTalentIdsByHeroId[heroId] ?? [];
+                const heroTalentRanks = state.talentProgression.talentRanksByHeroId[heroId] ?? {};
+                const currentRank = heroTalentRanks[talentId] ?? 0;
                 const availablePoints = state.talentProgression.talentPointsByHeroId[heroId] ?? 0;
-                if (availablePoints <= 0 || unlockedTalentIds.includes(talentId)) {
+                if (availablePoints <= 0 || currentRank >= (talentDefinition.maxRank ?? 3)) {
                     return {};
                 }
 
+                const nextRank = currentRank + 1;
+
                 const talentProgression = synchronizeTalentProgression(state.party, {
-                    unlockedTalentIdsByHeroId: {
-                        ...state.talentProgression.unlockedTalentIdsByHeroId,
-                        [heroId]: [...unlockedTalentIds, talentId],
+                    talentRanksByHeroId: {
+                        ...state.talentProgression.talentRanksByHeroId,
+                        [heroId]: {
+                            ...heroTalentRanks,
+                            [talentId]: nextRank,
+                        },
                     },
                     talentPointsByHeroId: {
                         ...state.talentProgression.talentPointsByHeroId,
@@ -208,7 +214,12 @@ export const createProgressionSlice = (
                         talentProgression,
                         equipmentProgression: state.equipmentProgression,
                     }),
-                    combatLog: prependCombatMessages(state.combatLog, `${hero.name} learned ${talentDefinition.name}.`),
+                    combatLog: prependCombatMessages(
+                        state.combatLog,
+                        currentRank === 0
+                            ? `${hero.name} learned ${talentDefinition.name} (Rank ${nextRank}).`
+                            : `${hero.name} upgraded ${talentDefinition.name} to Rank ${nextRank}.`,
+                    ),
                 };
             });
         },

--- a/src/game/store/types.ts
+++ b/src/game/store/types.ts
@@ -41,7 +41,7 @@ export interface PrestigeUpgrades {
 }
 
 export interface TalentProgressionState {
-    unlockedTalentIdsByHeroId: Record<string, string[]>;
+    talentRanksByHeroId: Record<string, Record<string, number>>;
     talentPointsByHeroId: Record<string, number>;
 }
 
@@ -65,7 +65,7 @@ export interface EquipmentProgressionState {
 }
 
 export const createEmptyTalentProgressionState = (): TalentProgressionState => ({
-    unlockedTalentIdsByHeroId: {},
+    talentRanksByHeroId: {},
     talentPointsByHeroId: {},
 });
 


### PR DESCRIPTION
## Summary
- convert talent progression from binary unlocks to fixed 3-rank talents with even-level point awards through the full rank cap
- update progression, simulation, persistence migration, roster/build UI, and balance snapshot seeding for rank-aware talents
- add ranked-talent coverage plus architecture doc updates for the new live model

## Testing
- npm run lint
- npm run build
- npm test

Closes #91