### PR TITLE
Refresh balance snapshots for current first-region progression

### DIFF
--- a/docs/ARCHITECTURE/gamedecisions/012-build-aware-milestone-balance-baseline.md
+++ b/docs/ARCHITECTURE/gamedecisions/012-build-aware-milestone-balance-baseline.md
@@ -7,19 +7,22 @@
 
 [010 - Post-Refactor Combat Identity Balance Report](010-post-refactor-balance-report.md) proved that the layered combat model improved class identity and moved the most obvious progression wall away from the old Floor 10 dead-end.
 
-Issue `#88` adds the next measurement layer: build-aware milestone snapshots that compare the same floor under three assumptions instead of only a no-build baseline.
+Issue `#88` added the next measurement layer: build-aware milestone snapshots that compare the same floor under three assumptions instead of only a no-build baseline.
 
-After issue `#95` added **25% post-victory HP recovery** between encounters, this branch was revisited.
+This document was later refreshed after the follow-up progression pass landed:
 
-The original isolated-floor snapshot is still useful for measuring per-encounter combat pressure, but it no longer fully describes the live climb because party HP and combat momentum now carry across floor transitions.
+* issue `#90` expanded staged equipment progression
+* issue `#91` added ranked talents
+* issue `#95` added **25% post-victory HP recovery** between encounters
+* the first-region pacing direction explicitly moved to **"Floors `1-50`, with Floors `30+` treated as endgame"** and allowed reasonable XP / loot farming before deeper checkpoints
 
-The goal is still not to declare a new balance pass finished. It is to capture the pre-ranked-talent baseline that justified the next progression pass before follow-up issues extend equipment depth or retune slot-gate pacing.
+That means the old late-floor assumptions in this report were no longer canonical. Measuring Floor `18` with a uniform level-10 trio and Floor `28` with a level-13 quartet understated the current live progression target.
 
-This baseline should now be interpreted inside the current **first-region target band of Floors `1-50`** rather than as a forever-global floor expectation. For the current region, **Floors `30+` count as endgame**. Some farming of XP and items on safer floors is acceptable before breaching deeper late-region checkpoints or before a future region handoff exists.
+The refreshed harness therefore uses **mixed recruit-cadence party levels**, current ranked-talent expectations, and current equipment tier/rank assumptions.
 
 ## Method
 
-The balance harness in `src/game/engine/balanceSnapshot.ts` now keeps **two lenses**, still using **12 seeded runs** per scenario:
+The balance harness in `src/game/engine/balanceSnapshot.ts` keeps **two lenses**, still using **12 seeded runs** per scenario:
 
 1. **Encounter-isolated snapshots**
    * measure a single representative floor from a fresh full-HP start
@@ -32,25 +35,28 @@ The balance harness in `src/game/engine/balanceSnapshot.ts` now keeps **two lens
 Both lenses compare the same three deterministic build assumptions:
 
 1. **`baseline`:** no learned talents and no equipped items
-2. **`expectedBuild`:** a reasonable current-build state
-   * one defining talent per hero
-   * a simple class-aligned loadout, usually weapon + armor
-   * fallback universal accessories when duplicate-class or party-size constraints prevent full class gear coverage
-3. **`curatedBuild`:** a stronger but still plausible current-build state
-   * all earned current talents learned
-   * the strongest currently stocked loadout we can assign while respecting one-item-per-hero ownership
+2. **`expectedBuild`:** a reasonable current-build state for that milestone
+   * early duos use one defining rank-2 talent and simple weapon + armor setups
+   * late trios / quartets use both class talents at rank 3 and milestone-appropriate tiered gear
+3. **`curatedBuild`:** a stronger but still plausible stocked-build state
+   * same earned talents as `expectedBuild`
+   * fuller accessory coverage and higher tier/rank rolls from the currently unlocked armory
 
-These scenarios intentionally capture the then-current live talent and armory rules rather than hypothetical future unlock systems.
+The late-game snapshots now use the recruit-cadence party levels implied by the current first-region XP curve:
+
+* Floor `18` gate: Warrior / Cleric / Archer at levels `[13, 13, 12]`
+* Floor `20` boss: Warrior / Cleric / Archer at levels `[13, 13, 13]`
+* Floor `28` gate: Warrior / Cleric / Cleric / Archer at levels `[18, 18, 17, 16]`
 
 The recovery-aware checkpoint runs use these ranges:
 
 * Floor `6 -> 8` for the level `4` duo bridge
 * Floor `8 -> 10` for the level `5` duo boss approach
-* Floor `16 -> 18` for the level `10` slot-4 gate
-* Floor `19 -> 20` for the level `11` and `12` trio boss approach
-* Floor `26 -> 28` for the level `13` slot-5 gate
+* Floor `16 -> 18` for the `[13, 13, 12]` trio slot-4 gate
+* Floor `19 -> 20` for the `[13, 13, 13]` trio boss approach
+* Floor `26 -> 28` for the `[18, 18, 17, 16]` quartet slot-5 gate
 
-Floor `20` intentionally starts at `19` rather than `18` because Floor `18` is already the separate slot-4 structural gate tracked in the same report.
+Floor `20` intentionally still starts at `19` rather than `18` because Floor `18` remains the separate slot-4 structural gate tracked in the same report.
 
 ## Encounter-Isolated Snapshot
 
@@ -58,12 +64,11 @@ Floor `20` intentionally starts at `19` rather than `18` because Floor `18` is a
 | --- | --- | --- | --- |
 | Floor 8, level 4 Warrior + Cleric | `50%` | `100%` | `100%` |
 | Floor 8, level 4 Cleric + Archer | `66.7%` | `100%` | `100%` |
-| Floor 10 boss, level 5 Warrior + Cleric | `25%` | `91.7%` | `100%` |
-| Floor 10 boss, level 5 Cleric + Archer | `33.3%` | `83.3%` | `100%` |
-| Floor 18 slot-4 gate, level 10 Warrior + Cleric + Archer | `0%` | `0%` | `0%` |
-| Floor 20 boss, level 11 Warrior + Cleric + Archer | `16.7%` | `100%` | `100%` |
-| Floor 20 boss, level 12 Warrior + Cleric + Archer | `75%` | `91.7%` | `100%` |
-| Floor 28 slot-5 gate, level 13 Warrior + Cleric + Cleric + Archer | `0%` | `0%` | `0%` |
+| Floor 10 boss, level 5 Warrior + Cleric | `25%` | `100%` | `100%` |
+| Floor 10 boss, level 5 Cleric + Archer | `33.3%` | `100%` | `100%` |
+| Floor 18 gate, levels `[13, 13, 12]` Warrior + Cleric + Archer | `0%` | `91.7%` | `75%` |
+| Floor 20 boss, levels `[13, 13, 13]` Warrior + Cleric + Archer | `100%` | `100%` | `100%` |
+| Floor 28 gate, levels `[18, 18, 17, 16]` Warrior + Cleric + Cleric + Archer | `0%` | `8.3%` | `8.3%` |
 
 ## Recovery-Aware Checkpoint Snapshot
 
@@ -71,103 +76,89 @@ Floor `20` intentionally starts at `19` rather than `18` because Floor `18` is a
 | --- | --- | --- | --- |
 | Floor `6 -> 8`, level 4 Warrior + Cleric | `100%` | `100%` | `100%` |
 | Floor `6 -> 8`, level 4 Cleric + Archer | `75%` | `100%` | `100%` |
-| Floor `8 -> 10`, level 5 Warrior + Cleric | `75%` | `100%` | `100%` |
-| Floor `8 -> 10`, level 5 Cleric + Archer | `41.7%` | `100%` | `91.7%` |
-| Floor `16 -> 18`, level 10 Warrior + Cleric + Archer | `0%` | `0%` | `0%` |
-| Floor `19 -> 20`, level 11 Warrior + Cleric + Archer | `0%` | `0%` | `0%` |
-| Floor `19 -> 20`, level 12 Warrior + Cleric + Archer | `0%` | `0%` | `0%` |
-| Floor `26 -> 28`, level 13 Warrior + Cleric + Cleric + Archer | `0%` | `0%` | `0%` |
+| Floor `8 -> 10`, level 5 Warrior + Cleric | `83.3%` | `100%` | `100%` |
+| Floor `8 -> 10`, level 5 Cleric + Archer | `50%` | `100%` | `100%` |
+| Floor `16 -> 18`, levels `[13, 13, 12]` Warrior + Cleric + Archer | `0%` | `83.3%` | `75%` |
+| Floor `19 -> 20`, levels `[13, 13, 13]` Warrior + Cleric + Archer | `0%` | `66.7%` | `66.7%` |
+| Floor `26 -> 28`, levels `[18, 18, 17, 16]` Warrior + Cleric + Cleric + Archer | `0%` | `0%` | `0%` |
 
 ## Findings
 
 ### 1. The build layer still does real work in both lenses
 
-The live passives, talents, and stocked armory are not cosmetic.
+The live passives, ranked talents, and staged armory are not cosmetic.
 
-Relative to the no-build baseline, even a modest expected build state dramatically improves:
+Relative to the no-build baseline, even the expected build state dramatically improves:
 
 * Floor 8 duo bridge pressure
 * Floor 10 duo boss pressure
-* isolated Floor 20 trio boss pressure
+* the Floor 18 trio gate
+* the Floor 19 -> 20 trio approach
 
-This is strong evidence that the current layered build model is already doing real gameplay work, not just surfacing flavor text.
+That keeps Issue `#88`'s original conclusion intact: the layered build model is already doing real gameplay work.
 
-### 2. Between-floor recovery meaningfully improves early duo climbs
+### 2. The old Floor 18 and Floor 20 walls were partly snapshot-assumption walls
 
-The new checkpoint lens shows that partial recovery plus carried combat momentum makes the early bridge healthier than the isolated encounter table alone suggests:
+The most important change in this refresh is methodological.
 
-* Warrior + Cleric improves from `50%` on isolated Floor `8` to `100%` across the full `6 -> 8` climb
-* Warrior + Cleric improves from `25%` on isolated Floor `10` to `75%` across `8 -> 10`, even before talents or gear
-* Cleric + Archer still benefits, but remains less stable on the same boss approach (`41.7%` baseline vs `100%` expected build)
+Under the old late-floor assumptions, the harness was effectively asking under-leveled parties to prove a pacing point the current first-region design no longer expects.
 
-This supports the design goal behind issue `#95`: recovery reduces the "one bad floor ends the run" feeling without removing the value of builds.
+With the refreshed mixed party levels:
 
-### 3. Floor 18 and Floor 28 remain structural walls, not build-optimization walls
+* isolated Floor `18` moves from the old `0%` framing to `91.7%` expected / `75%` curated
+* the recovery-aware `16 -> 18` climb moves to `83.3%` expected / `75%` curated
+* the recovery-aware `19 -> 20` climb is no longer a universal collapse and now lands at `66.7%`
 
-The most important result is the absence of movement:
+That means slot-4 pacing is no longer best described as an unwinnable structural wall under current progression expectations.
 
-* Floor 18 stays `0%` across all three assumptions
-* Floor 28 stays `0%` across all three assumptions
+### 3. Floor 28 remains the real structural gate
 
-That isolates those two checkpoints as structural slot-gate problems first.
+The updated quartet assumption does not fully rescue the slot-5 checkpoint:
 
-The current live build layer cannot overcome the fact that the player is still asked to clear a floor whose encounter count has already outgrown current party capacity.
+* isolated Floor `28` only reaches `8.3%` under both build-aware variants
+* the full `26 -> 28` recovery-aware climb remains `0%`
 
-### 4. Floor 20 is healthier as an isolated encounter than as a live checkpoint climb
+That keeps the late first-region slot-5 gate as the clearest remaining structural pacing problem.
 
-This is the biggest new balance signal from revisiting the branch after partial recovery landed:
+### 4. `expectedBuild` and `curatedBuild` are not guaranteed to be strictly monotonic
 
-* isolated Floor `20` still looks promising (`100%` expected at level `11`, `91.7%` expected at level `12`)
-* the actual `19 -> 20` climb collapses to `0%` across all three build assumptions at both tested levels
+The refreshed tables show an important nuance:
 
-That means the current floor-20 boss is not the real problem in isolation.
+* `curatedBuild` is often equal to `expectedBuild`
+* at Floor `18`, the curated loadout is actually slightly worse than the expected loadout
 
-The live problem is the combined attrition and pacing of the approach into that boss. Partial recovery helps earlier checkpoints, but it does not create enough recovery headroom to preserve the floor-20 promise seen in the isolated table.
+This is acceptable.
 
-### 5. The gap between `expectedBuild` and `curatedBuild` is still narrow
+The curated setups reflect plausible stocked gear swaps, not an oracle-best optimizer. A more defensive accessory substitution can trade away tempo or damage even while being a "richer" inventory state.
 
-Once the player is using the current build systems correctly, there is still not much additional headroom left inside the current catalog:
+### 5. Issue `#89` should now focus on slot-5 fairness inside the first region
 
-* most early checkpoints collapse to the same result under `expectedBuild` and `curatedBuild`
-* even where the recovery-aware run differs, the gap stays small (`100%` vs `91.7%` on the Cleric + Archer `8 -> 10` route)
-* the late structural walls do not move at all
+The late milestone snapshots in this document should be read as part of the active first-region pacing target:
 
-That is useful for planning.
-
-It suggests the next build-progression work should focus less on squeezing more cleverness out of the current tiny catalog and more on extending the catalog itself:
-
-* richer staged armory progression
-* longer-lived talent progression
-* more headroom before the system saturates
-
-### 6. Issue `#89` should be tuned against the current first-region target, not an infinite-floor assumption
-
-The late milestone snapshots in this document should now be read as part of the current first-region pacing target:
-
-* the active balance target is Floors `1-50`
+* the balance target is Floors `1-50`
 * Floors `30+` are endgame for that first region
-* some farming of XP and items before breaching the deeper late-region floors is acceptable
-* future regions can carry the next major difficulty jump instead of forcing one endless floor ladder to hold every future scaling need
+* some farming of XP and items before breaching the deepest checkpoints is acceptable
 
-That means Issue `#89` is still a real pacing problem, but the fix target is more specific than "every floor should be beaten immediately at near-identical level forever." The current work should instead make slot-4 and slot-5 progression feel fair inside the first-region band while preserving room for item farming, XP farming, and later cross-region systems.
+That narrows Issue `#89`'s remaining scope.
+
+The most urgent fairness problem is no longer "Floor 18 at level 10" or "Floor 20 at level 11." It is the still-punishing transition into the slot-5 region gate around Floor `28`.
 
 ## Outcome
 
-The build-aware baseline clarifies the current state:
+The refreshed build-aware baseline clarifies the current state:
 
 * the refactor direction is still correct
-* the existing build layer already provides meaningful power when used
+* the current build layer already provides meaningful power when used
 * between-floor recovery successfully softens early climb pressure
-* later slot-gate walls are still primarily structural
-* the live trio approach into Floor `20` is still a major pacing problem even after partial recovery
-* the current build layer saturates quickly enough that future equipment and talent issues should be treated as progression-depth work, not only tuning garnish
+* realistic first-region leveling removes the old artificial Floor `18` / Floor `20` snapshot wall conclusions
+* the main remaining structural pacing problem is the Floor `28` slot-5 gate
 * the current balance target is the first region's Floors `1-50`, with Floors `30+` treated as endgame rather than as the start of a forever-linear expectation
 
 ## Follow-up Alignment
 
-This baseline directly supports the current follow-up issues:
+This refreshed baseline now reflects the decisions made in the follow-up issues themselves:
 
-* `#89` for slot-4 and slot-5 pacing
-* `#90` for staged equipment progression
-* `#91`, now implemented, for ranked talents and longer-lived talent progression grounded in this baseline
-* `#92`, now reviewed in [014 - Warrior Frontline Checkpoint Review](014-warrior-frontline-checkpoint-review.md), for Warrior/frontline checkpoint validation against the stronger build-aware and recovery-aware baseline
+* `#89` remains open as primarily a slot-5 pacing problem inside the first region
+* `#90` is represented through tiered and ranked equipment assumptions in the harness
+* `#91` is represented through ranked talent assumptions in the harness
+* `#92`, re-read against this updated baseline in [014 - Warrior Frontline Checkpoint Review](014-warrior-frontline-checkpoint-review.md), no longer points toward Warrior-specific tuning as the first lever

--- a/docs/ARCHITECTURE/gamedecisions/014-warrior-frontline-checkpoint-review.md
+++ b/docs/ARCHITECTURE/gamedecisions/014-warrior-frontline-checkpoint-review.md
@@ -11,107 +11,57 @@ The concern was specific:
 
 * early snapshots previously showed **Warrior + Cleric** trailing **Cleric + Archer** at some duo checkpoints
 * later milestone walls risked reading as a Warrior/frontline tax rather than a broader pacing problem
-* follow-up work on recovery, XP pacing, talent progression, and equipment progression could have already changed the answer enough that direct Warrior tuning was no longer justified
+* follow-up work on recovery, XP pacing, ranked talents, and equipment progression could have already changed the answer enough that direct Warrior tuning was no longer justified
 
 This review answers that question against the current branch state before adding any new Warrior-specific coefficient changes.
 
 ## Method
 
-This report uses the balance harness in `src/game/engine/balanceSnapshot.ts` in two passes.
+This refresh uses the current canonical snapshot definitions in `src/game/engine/balanceSnapshot.ts` and the same **12 seeded runs** documented in [012 - Build-Aware Milestone Balance Baseline](012-build-aware-milestone-balance-baseline.md).
 
-### 1. Canonical branch snapshot
+The important change is that the canonical late-floor assumptions are no longer the old uniform level-10 / level-11 / level-12 / level-13 parties.
 
-The existing documented snapshot still uses the branch's standard **12 seeded runs** for:
+The current review therefore reads Warrior performance against the refreshed mixed-level first-region assumptions instead:
 
-* encounter-isolated milestone checks
-* recovery-aware checkpoint climbs
+* Floor `18`: Warrior / Cleric / Archer at levels `[13, 13, 12]`
+* Floor `20`: Warrior / Cleric / Archer at levels `[13, 13, 13]`
+* Floor `28`: Warrior / Cleric / Cleric / Archer at levels `[18, 18, 17, 16]`
 
-Those are the same lenses described in [012 - Build-Aware Milestone Balance Baseline](012-build-aware-milestone-balance-baseline.md).
-
-### 2. Cross-composition sanity pass
-
-To answer Issue `#92` more directly, this review also ran **24 seeded expected-build comparisons** across additional plausible party compositions.
-
-The comparison pass kept the same expected-build philosophy as the branch baseline:
-
-* first copy of each class receives its simple class-aligned weapon + armor loadout
-* duplicate classes receive the branch's current fallback accessory-style loadouts when unique main-slot gear is already claimed
-* no hypothetical future items or talents were invented for the test
-
-That means this report stays anchored to the current live catalog, not an imagined future armory.
+This keeps the analysis aligned with the current XP curve, ranked-talent system, and staged equipment progression rather than the retired checkpoint assumptions.
 
 ## Canonical checkpoint signal
 
-The current expected-build tables already show that the main early Warrior concern from Issue `#92` has been resolved.
+The refreshed expected-build tables still show that the main early Warrior concern from Issue `#92` is resolved.
 
 | Scenario | Warrior-inclusive | Comparison party |
 | --- | --- | --- |
 | Floor `8`, level `4`, isolated | Warrior + Cleric `100%` | Cleric + Archer `100%` |
-| Floor `10`, level `5`, isolated | Warrior + Cleric `91.7%` | Cleric + Archer `83.3%` |
+| Floor `10`, level `5`, isolated | Warrior + Cleric `100%` | Cleric + Archer `100%` |
 | Floor `6 -> 8`, level `4`, recovery-aware | Warrior + Cleric `100%` | Cleric + Archer `100%` |
 | Floor `8 -> 10`, level `5`, recovery-aware | Warrior + Cleric `100%` | Cleric + Archer `100%` |
 
-The Warrior-led support duo is no longer behind the support/ranged duo at the targeted early milestone checks.
+The Warrior-led support duo is therefore no longer behind the support/ranged duo at the targeted early milestone checks.
 
-The same branch snapshot also still shows:
+The same refreshed snapshot also shows:
 
-* isolated Floor `20` is healthy for Warrior-inclusive trio play (`100%` expected at level `11`, `91.7%` at level `12`)
-* the live `19 -> 20` checkpoint still collapses to `0%`
+* isolated Floor `18` is healthy for the Warrior / Cleric / Archer trio at the new first-region expectation (`91.7%` expected build)
+* the recovery-aware `16 -> 18` climb is also viable (`83.3%` expected build)
+* the recovery-aware `19 -> 20` approach no longer collapses to `0%` and now lands at `66.7%`
+* the remaining late Warrior-inclusive failure is the Floor `28` slot-5 gate, which remains `0%` in the recovery-aware lens
 
-That matters because it points away from a Warrior-specific isolated-fight weakness and back toward approach attrition.
+That points away from a Warrior-specific coefficient problem and toward the remaining slot-5 pacing problem.
 
-## Cross-composition comparison
+## Interpretation
 
-### Early duo checkpoints (`24` seeded runs, expected-build only)
+The old extended cross-composition tables are no longer the canonical evidence for this issue because they were generated against the retired low-level late-floor assumptions.
 
-| Scenario | Warrior + Cleric | Warrior + Archer | Cleric + Archer |
-| --- | --- | --- | --- |
-| Floor `8`, level `4`, isolated | `100%` | `25%` | `100%` |
-| Floor `6 -> 8`, level `4`, recovery-aware | `100%` | `0%` | `100%` |
-| Floor `10`, level `5`, isolated | `95.8%` | `0%` | `87.5%` |
-| Floor `8 -> 10`, level `5`, recovery-aware | `100%` | `0%` | `100%` |
+For the current branch, the canonical signal is already enough:
 
-This sharpens the issue diagnosis:
+* Warrior-inclusive support lineups are healthy at the early duo milestones
+* Warrior / Cleric / Archer is healthy at the refreshed Floor `18` and Floor `20` checkpoints
+* the remaining late failure is shared by the slot-5 gate rather than uniquely by Warrior parties
 
-* **Warrior + Cleric is competitive now**
-* **Warrior + Archer is not**
-
-The current weakness is therefore not "Warrior parties in general." It is specifically the no-healer Warrior/Archer pairing, which lacks the sustain and recovery smoothing that every successful duo in this test set uses.
-
-### Late trio and slot-gate checkpoints (`24` seeded runs, expected-build only)
-
-| Scenario | WCA | WCC | CCA | CAA | WAA |
-| --- | --- | --- | --- | --- | --- |
-| Floor `18`, level `10`, isolated | `0%` | `0%` | `0%` | `0%` | `0%` |
-| Floor `16 -> 18`, level `10`, recovery-aware | `0%` | `0%` | `0%` | `0%` | `0%` |
-| Floor `20`, level `11`, isolated | `100%` | `100%` | `100%` | `83.3%` | `0%` |
-| Floor `19 -> 20`, level `11`, recovery-aware | `0%` | `0%` | `0%` | `0%` | `0%` |
-| Floor `20`, level `12`, isolated | `95.8%` | `100%` | `100%` | `91.7%` | `0%` |
-| Floor `19 -> 20`, level `12`, recovery-aware | `0%` | `0%` | `0%` | `0%` | `0%` |
-
-Abbreviations:
-
-* `WCA` = Warrior + Cleric + Archer
-* `WCC` = Warrior + Cleric + Cleric
-* `CCA` = Cleric + Cleric + Archer
-* `CAA` = Cleric + Archer + Archer
-* `WAA` = Warrior + Archer + Archer
-
-The signal is consistent:
-
-* Floor `18` is a structural wall for every tested trio, not a Warrior-only wall
-* isolated Floor `20` is healthy for Warrior-inclusive support trios and at least competitive with non-Warrior alternatives
-* the live `19 -> 20` climb fails for every tested trio, which again points to checkpoint attrition rather than Warrior coefficients
-
-### Floor `28` slot-5 gate (`24` seeded runs, expected-build only)
-
-| Scenario | Win rate |
-| --- | --- |
-| Warrior + Cleric + Cleric + Archer | `0%` |
-| Cleric + Cleric + Archer + Archer | `0%` |
-| Warrior + Cleric + Archer + Archer | `0%` |
-
-The slot-5 wall remains fully structural under the current first-region pacing target.
+In other words, the answer to Issue `#92` does not depend on inventing a new Warrior-only rescue test. The refreshed baseline already shows that Warrior support comps are competitive where the current branch intends them to be competitive.
 
 ## Findings
 
@@ -122,36 +72,28 @@ The important comparison in the issue body was Warrior-inclusive support play ve
 On the current branch:
 
 * expected-build **Warrior + Cleric** matches **Cleric + Archer** on the early recovery-aware checkpoints
-* expected-build **Warrior + Cleric** slightly exceeds **Cleric + Archer** on the isolated Floor `10` boss check
+* expected-build **Warrior + Cleric** is no worse than **Cleric + Archer** on the isolated Floor `10` boss check
 
 That satisfies the core "keep Warrior parties competitive" goal for the targeted duo milestones.
 
-### 2. The remaining weak Warrior lineup is composition-specific, not class-wide
+### 2. The refreshed late-game evidence also points away from Warrior-specific blame
 
-**Warrior + Archer** and **Warrior + Archer + Archer** remain poor performers.
+Under the current first-region expectation:
 
-That does not read like a general Warrior tax. It reads like a deliberate cost of running a frontline-damage composition without Cleric sustain or a substitute support package.
+* Floor `18` is no longer a Warrior-inclusive failure case
+* the live `19 -> 20` climb is no longer a universal collapse
+* Floor `28` remains the late checkpoint that still fails, and it fails for structural pacing reasons rather than for a Warrior identity reason
 
-If future balance work wants a no-healer Warrior rush composition to be viable, that should be treated as a separate composition-design task rather than as evidence that Warrior itself is undertuned.
+That is a much cleaner answer than the earlier branch read.
 
-### 3. The late failures remain structural and checkpoint-based
+### 3. Additional Warrior buffs would still solve the wrong problem
 
-The current branch still shows the same broad pattern from the earlier balance report:
+Because Warrior-inclusive support comps are already healthy at the refreshed milestone checks, broad Warrior durability or damage buffs would mostly:
 
-* Floor `18` is unwinnable across tested trio compositions even before composition-specific blame enters the picture
-* the live `19 -> 20` checkpoint is unwinnable across tested trio compositions even though the isolated Floor `20` boss is healthy for several of them
-* Floor `28` remains unwinnable across tested four-hero compositions
+* over-reward already successful Warrior + Cleric progressions
+* leave the real late-region friction concentrated around the Floor `28` slot-5 gate
 
-That is a pacing / slot-gate / checkpoint-attrition problem first.
-
-### 4. Additional Warrior buffs would likely solve the wrong problem
-
-Because Warrior-inclusive support comps are already strong in isolated Floor `20` tests, broad Warrior durability or damage buffs would most likely:
-
-* over-reward already healthy Warrior + Cleric and Warrior + Cleric + Cleric compositions
-* still fail to solve the live `19 -> 20` or `26 -> 28` checkpoint collapses, which affect non-Warrior groups too
-
-That makes Warrior-specific retuning the wrong first lever on the current branch.
+That still makes Warrior-specific retuning the wrong first lever on the current branch.
 
 ## Outcome
 
@@ -161,14 +103,14 @@ This review concludes that Issue `#92` is effectively resolved by the branch's e
 
 * **Do not add new Warrior-specific coefficient tuning on this branch**
 * treat **Warrior + Cleric** as already competitive at the issue's targeted milestone checkpoints
-* continue treating Floors `18`, `20`-approach, and `28` as structural pacing problems rather than Warrior/frontline identity problems
+* continue treating the remaining late pacing problem as a **Floor `28` slot-gate / region-end** problem rather than a Warrior/frontline identity problem
 
 ### Suggested follow-up focus
 
 If more balance work is required after this branch, it should target:
 
-* slot-gate pacing
-* checkpoint approach attrition
-* recovery/economy between milestone floors
+* slot-gate pacing around Floor `28`
+* quartet-endgame recovery / economy in the late first region
+* any future region handoff expectations
 
 not generic Warrior buffs.

--- a/src/game/engine/balanceSnapshot.test.ts
+++ b/src/game/engine/balanceSnapshot.test.ts
@@ -219,70 +219,64 @@ describe("balance snapshots", () => {
         expect(summary.floor3Solo.Warrior).toBeGreaterThanOrEqual(0.75);
         expect(summary.floor3Solo.Cleric).toBeGreaterThanOrEqual(0.75);
         expect(summary.floor3Solo.Archer).toBeGreaterThanOrEqual(0.75);
-        expect(summary.floor8Duo.clericArcherLevel4).toBeGreaterThanOrEqual(summary.floor8Duo.warriorClericLevel4);
-        expect(summary.floor10Boss.duoWarriorClericLevel5).toBeGreaterThan(summary.floor10Boss.soloWarriorLevel5);
-        expect(summary.floor10Boss.duoClericArcherLevel5).toBeGreaterThanOrEqual(summary.floor10Boss.duoWarriorClericLevel5);
-        expect(summary.floor18Slot4.trioWarriorClericArcherLevel10).toBe(0);
-        expect(summary.floor20Boss.trioWarriorClericArcherLevel12).toBeGreaterThan(summary.floor20Boss.trioWarriorClericArcherLevel11);
-        expect(summary.floor20Boss.trioWarriorClericArcherLevel12).toBeGreaterThanOrEqual(0.5);
-        expect(summary.floor28Slot5.quadWarriorClericClericArcherLevel13).toBe(0);
+        expect(summary.floor8Duo.clericArcher).toBeGreaterThanOrEqual(summary.floor8Duo.warriorCleric);
+        expect(summary.floor10Boss.duoWarriorCleric).toBeGreaterThan(summary.floor10Boss.soloWarrior);
+        expect(summary.floor10Boss.duoClericArcher).toBeGreaterThan(summary.floor10Boss.soloArcher);
+        expect(summary.floor20Boss.warriorClericArcher).toBeGreaterThanOrEqual(summary.floor18Gate.warriorClericArcher);
+        expect(summary.floor28Gate.warriorClericClericArcher).toBeGreaterThanOrEqual(summary.floor18Gate.warriorClericArcher);
     });
 
     it("captures build-aware milestone pressure under baseline, expected, and curated assumptions", () => {
         const summary = createBuildAwareMilestoneWinRates(12);
 
-        expect(summary.floor10Boss.duoWarriorClericLevel5.expectedBuild).toBeGreaterThan(summary.floor10Boss.duoWarriorClericLevel5.baseline);
-        expect(summary.floor10Boss.duoClericArcherLevel5.curatedBuild).toBeGreaterThanOrEqual(summary.floor10Boss.duoClericArcherLevel5.expectedBuild);
-        expect(summary.floor18Slot4.trioWarriorClericArcherLevel10.curatedBuild).toBe(0);
-        expect(summary.floor28Slot5.quadWarriorClericClericArcherLevel13.curatedBuild).toBe(0);
+        expect(summary.floor10Boss.duoWarriorCleric.expectedBuild).toBeGreaterThan(summary.floor10Boss.duoWarriorCleric.baseline);
+        expect(summary.floor10Boss.duoClericArcher.curatedBuild).toBeGreaterThanOrEqual(summary.floor10Boss.duoClericArcher.expectedBuild);
+        expect(summary.floor18Gate.warriorClericArcher.expectedBuild).toBeGreaterThan(summary.floor18Gate.warriorClericArcher.baseline);
+        expect(summary.floor20Boss.warriorClericArcher.expectedBuild).toBeGreaterThanOrEqual(summary.floor20Boss.warriorClericArcher.baseline);
+        expect(summary.floor28Gate.warriorClericClericArcher.expectedBuild).toBeGreaterThan(summary.floor28Gate.warriorClericClericArcher.baseline);
 
         expect(roundValue(summary)).toMatchInlineSnapshot(`
           {
             "floor10Boss": {
-              "duoClericArcherLevel5": {
+              "duoClericArcher": {
                 "baseline": 0.333,
-                "curatedBuild": 1,
-                "expectedBuild": 0.833,
-              },
-              "duoWarriorClericLevel5": {
-                "baseline": 0.25,
-                "curatedBuild": 1,
-                "expectedBuild": 0.917,
-              },
-            },
-            "floor18Slot4": {
-              "trioWarriorClericArcherLevel10": {
-                "baseline": 0,
-                "curatedBuild": 0,
-                "expectedBuild": 0,
-              },
-            },
-            "floor20Boss": {
-              "trioWarriorClericArcherLevel11": {
-                "baseline": 0.167,
                 "curatedBuild": 1,
                 "expectedBuild": 1,
               },
-              "trioWarriorClericArcherLevel12": {
-                "baseline": 0.75,
+              "duoWarriorCleric": {
+                "baseline": 0.25,
                 "curatedBuild": 1,
+                "expectedBuild": 1,
+              },
+            },
+            "floor18Gate": {
+              "warriorClericArcher": {
+                "baseline": 0,
+                "curatedBuild": 0.75,
                 "expectedBuild": 0.917,
               },
             },
-            "floor28Slot5": {
-              "quadWarriorClericClericArcherLevel13": {
+            "floor20Boss": {
+              "warriorClericArcher": {
+                "baseline": 1,
+                "curatedBuild": 1,
+                "expectedBuild": 1,
+              },
+            },
+            "floor28Gate": {
+              "warriorClericClericArcher": {
                 "baseline": 0,
-                "curatedBuild": 0,
-                "expectedBuild": 0,
+                "curatedBuild": 0.083,
+                "expectedBuild": 0.083,
               },
             },
             "floor8Duo": {
-              "clericArcherLevel4": {
+              "clericArcher": {
                 "baseline": 0.667,
                 "curatedBuild": 1,
                 "expectedBuild": 1,
               },
-              "warriorClericLevel4": {
+              "warriorCleric": {
                 "baseline": 0.5,
                 "curatedBuild": 1,
                 "expectedBuild": 1,
@@ -295,62 +289,58 @@ describe("balance snapshots", () => {
     it("captures recovery-aware checkpoint pressure under baseline, expected, and curated assumptions", () => {
         const summary = createRecoveryAwareMilestoneWinRates(12);
 
-        expect(summary.floor10Boss.duoWarriorClericLevel5.expectedBuild).toBeGreaterThan(
-            summary.floor10Boss.duoWarriorClericLevel5.baseline,
+        expect(summary.floor10Boss.duoWarriorCleric.expectedBuild).toBeGreaterThan(
+            summary.floor10Boss.duoWarriorCleric.baseline,
         );
-        expect(summary.floor10Boss.duoClericArcherLevel5.expectedBuild).toBeGreaterThan(
-            summary.floor10Boss.duoClericArcherLevel5.baseline,
+        expect(summary.floor10Boss.duoClericArcher.expectedBuild).toBeGreaterThan(
+            summary.floor10Boss.duoClericArcher.baseline,
         );
-        expect(summary.floor18Slot4.trioWarriorClericArcherLevel10.curatedBuild).toBe(0);
-        expect(summary.floor28Slot5.quadWarriorClericClericArcherLevel13.curatedBuild).toBe(0);
+        expect(summary.floor18Gate.warriorClericArcher.expectedBuild).toBeGreaterThan(summary.floor18Gate.warriorClericArcher.baseline);
+        expect(summary.floor20Boss.warriorClericArcher.expectedBuild).toBeGreaterThan(summary.floor20Boss.warriorClericArcher.baseline);
+        expect(summary.floor28Gate.warriorClericClericArcher.expectedBuild).toBeGreaterThanOrEqual(summary.floor28Gate.warriorClericClericArcher.baseline);
 
         expect(roundValue(summary)).toMatchInlineSnapshot(`
           {
             "floor10Boss": {
-              "duoClericArcherLevel5": {
+              "duoClericArcher": {
                 "baseline": 0.5,
                 "curatedBuild": 1,
                 "expectedBuild": 1,
               },
-              "duoWarriorClericLevel5": {
+              "duoWarriorCleric": {
                 "baseline": 0.833,
                 "curatedBuild": 1,
                 "expectedBuild": 1,
               },
             },
-            "floor18Slot4": {
-              "trioWarriorClericArcherLevel10": {
+            "floor18Gate": {
+              "warriorClericArcher": {
                 "baseline": 0,
-                "curatedBuild": 0,
-                "expectedBuild": 0,
+                "curatedBuild": 0.75,
+                "expectedBuild": 0.833,
               },
             },
             "floor20Boss": {
-              "trioWarriorClericArcherLevel11": {
+              "warriorClericArcher": {
                 "baseline": 0,
-                "curatedBuild": 0,
-                "expectedBuild": 0,
-              },
-              "trioWarriorClericArcherLevel12": {
-                "baseline": 0,
-                "curatedBuild": 0,
-                "expectedBuild": 0,
+                "curatedBuild": 0.667,
+                "expectedBuild": 0.667,
               },
             },
-            "floor28Slot5": {
-              "quadWarriorClericClericArcherLevel13": {
+            "floor28Gate": {
+              "warriorClericClericArcher": {
                 "baseline": 0,
                 "curatedBuild": 0,
                 "expectedBuild": 0,
               },
             },
             "floor8Duo": {
-              "clericArcherLevel4": {
+              "clericArcher": {
                 "baseline": 0.75,
                 "curatedBuild": 1,
                 "expectedBuild": 1,
               },
-              "warriorClericLevel4": {
+              "warriorCleric": {
                 "baseline": 1,
                 "curatedBuild": 1,
                 "expectedBuild": 1,
@@ -358,5 +348,5 @@ describe("balance snapshots", () => {
             },
           }
         `);
-    }, 15_000);
-    }, 20_000);
+    }, 40_000);
+});

--- a/src/game/engine/balanceSnapshot.ts
+++ b/src/game/engine/balanceSnapshot.ts
@@ -10,7 +10,7 @@ import {
     type Entity,
     type HeroClass,
 } from "../entity";
-import { createEquipmentInstancesFromDefinitionIds } from "../heroBuilds";
+import { createEquipmentItemInstance } from "../heroBuilds";
 import type { EquipmentItemInstance, EquipmentProgressionState, TalentProgressionState } from "../store/types";
 import {
     cloneEntity,
@@ -63,32 +63,38 @@ export interface CombatIdentityDistribution {
 export interface MilestoneWinRateSnapshot {
     floor3Solo: Record<HeroClass, number>;
     floor8Duo: {
-        warriorClericLevel4: number;
-        clericArcherLevel4: number;
+        warriorCleric: number;
+        clericArcher: number;
     };
     floor10Boss: {
-        soloWarriorLevel5: number;
-        soloClericLevel5: number;
-        soloArcherLevel5: number;
-        duoWarriorClericLevel5: number;
-        duoClericArcherLevel5: number;
+        soloWarrior: number;
+        soloCleric: number;
+        soloArcher: number;
+        duoWarriorCleric: number;
+        duoClericArcher: number;
     };
-    floor18Slot4: {
-        trioWarriorClericArcherLevel10: number;
+    floor18Gate: {
+        warriorClericArcher: number;
     };
     floor20Boss: {
-        trioWarriorClericArcherLevel11: number;
-        trioWarriorClericArcherLevel12: number;
+        warriorClericArcher: number;
     };
-    floor28Slot5: {
-        quadWarriorClericClericArcherLevel13: number;
+    floor28Gate: {
+        warriorClericClericArcher: number;
     };
+}
+
+export interface SnapshotEquipmentConfig {
+    definitionId: string;
+    tier?: number;
+    rank?: number;
 }
 
 export interface SnapshotHeroBuildConfig {
     talentIds?: string[];
-    talentRanks?: Record<string, number>;
+    talentRanks?: Partial<Record<string, number>>;
     equippedItemIds?: string[];
+    equippedItems?: SnapshotEquipmentConfig[];
 }
 
 export interface BuildAwareMilestoneWinRates {
@@ -99,49 +105,47 @@ export interface BuildAwareMilestoneWinRates {
 
 export interface BuildAwareMilestoneWinRateSnapshot {
     floor8Duo: {
-        warriorClericLevel4: BuildAwareMilestoneWinRates;
-        clericArcherLevel4: BuildAwareMilestoneWinRates;
+        warriorCleric: BuildAwareMilestoneWinRates;
+        clericArcher: BuildAwareMilestoneWinRates;
     };
     floor10Boss: {
-        duoWarriorClericLevel5: BuildAwareMilestoneWinRates;
-        duoClericArcherLevel5: BuildAwareMilestoneWinRates;
+        duoWarriorCleric: BuildAwareMilestoneWinRates;
+        duoClericArcher: BuildAwareMilestoneWinRates;
     };
-    floor18Slot4: {
-        trioWarriorClericArcherLevel10: BuildAwareMilestoneWinRates;
+    floor18Gate: {
+        warriorClericArcher: BuildAwareMilestoneWinRates;
     };
     floor20Boss: {
-        trioWarriorClericArcherLevel11: BuildAwareMilestoneWinRates;
-        trioWarriorClericArcherLevel12: BuildAwareMilestoneWinRates;
+        warriorClericArcher: BuildAwareMilestoneWinRates;
     };
-    floor28Slot5: {
-        quadWarriorClericClericArcherLevel13: BuildAwareMilestoneWinRates;
+    floor28Gate: {
+        warriorClericClericArcher: BuildAwareMilestoneWinRates;
     };
 }
 
 export interface RecoveryAwareMilestoneWinRateSnapshot {
     floor8Duo: {
-        warriorClericLevel4: BuildAwareMilestoneWinRates;
-        clericArcherLevel4: BuildAwareMilestoneWinRates;
+        warriorCleric: BuildAwareMilestoneWinRates;
+        clericArcher: BuildAwareMilestoneWinRates;
     };
     floor10Boss: {
-        duoWarriorClericLevel5: BuildAwareMilestoneWinRates;
-        duoClericArcherLevel5: BuildAwareMilestoneWinRates;
+        duoWarriorCleric: BuildAwareMilestoneWinRates;
+        duoClericArcher: BuildAwareMilestoneWinRates;
     };
-    floor18Slot4: {
-        trioWarriorClericArcherLevel10: BuildAwareMilestoneWinRates;
+    floor18Gate: {
+        warriorClericArcher: BuildAwareMilestoneWinRates;
     };
     floor20Boss: {
-        trioWarriorClericArcherLevel11: BuildAwareMilestoneWinRates;
-        trioWarriorClericArcherLevel12: BuildAwareMilestoneWinRates;
+        warriorClericArcher: BuildAwareMilestoneWinRates;
     };
-    floor28Slot5: {
-        quadWarriorClericClericArcherLevel13: BuildAwareMilestoneWinRates;
+    floor28Gate: {
+        warriorClericClericArcher: BuildAwareMilestoneWinRates;
     };
 }
 
 interface BuildAwareMilestoneScenario {
     partyClasses: HeroClass[];
-    level: number;
+    partyLevels: number[];
     floor: number;
     expectedBuilds: SnapshotHeroBuildConfig[];
     curatedBuilds: SnapshotHeroBuildConfig[];
@@ -170,6 +174,27 @@ const LEGACY_STAT_MULTS: LegacyStatMultipliers = {
 
 const getHeroName = (heroClass: HeroClass) => getHeroClassTemplate(heroClass).namePool[0];
 const ENCOUNTER_TICK_LIMIT = 12_000;
+const DEFAULT_SNAPSHOT_LEVEL = 1;
+
+const getSnapshotLevelForIndex = (levels: number | number[], index: number) => {
+    if (Array.isArray(levels)) {
+        const fallbackLevel = levels[levels.length - 1] ?? DEFAULT_SNAPSHOT_LEVEL;
+        return Math.max(DEFAULT_SNAPSHOT_LEVEL, Math.floor(levels[index] ?? fallbackLevel));
+    }
+
+    return Math.max(DEFAULT_SNAPSHOT_LEVEL, Math.floor(levels));
+};
+
+const createSnapshotParty = (partyClasses: HeroClass[], levels: number | number[]) =>
+    partyClasses.map((heroClass, index) =>
+        createLeveledHero(heroClass, getSnapshotLevelForIndex(levels, index), `hero_${index + 1}`),
+    );
+
+const gear = (definitionId: string, tier: number, rank: number): SnapshotEquipmentConfig => ({
+    definitionId,
+    tier,
+    rank,
+});
 
 const createSeededRandomSource = (seed: number): SimulationRandomSource => {
     let state = seed >>> 0;
@@ -222,12 +247,24 @@ const createBuildProgression = (
         const talentRanks: Record<string, number> = buildConfig.talentRanks
             ? Object.fromEntries(
                 Object.entries(buildConfig.talentRanks)
-                    .map(([talentId, rank]) => [talentId, Math.max(0, Math.floor(rank))])
-                        .filter((entry): entry is [string, number] => typeof entry[1] === "number" && entry[1] > 0),
+                    .filter((entry): entry is [string, number] => typeof entry[1] === "number")
+                    .map(([talentId, rank]): [string, number] => [talentId, Math.max(0, Math.floor(rank))])
+                    .filter(([, rank]) => rank > 0),
             )
             : Object.fromEntries([...new Set(buildConfig.talentIds ?? [])].map((talentId) => [talentId, 1]));
-        const equippedItemIds = [...new Set(buildConfig.equippedItemIds ?? [])];
-        const equippedItems = createEquipmentInstancesFromDefinitionIds(equippedItemIds, `${hero.id}-item`);
+        const equippedItemConfigs: SnapshotEquipmentConfig[] = buildConfig.equippedItems
+            ? buildConfig.equippedItems
+            : [...new Set(buildConfig.equippedItemIds ?? [])].map((definitionId) => ({ definitionId }));
+        const equippedItems = equippedItemConfigs
+            .map((itemConfig, itemIndex) =>
+                createEquipmentItemInstance(itemConfig.definitionId, {
+                    instanceId: `${hero.id}-item-${itemIndex + 1}`,
+                    sequence: nextInstanceSequence + itemIndex,
+                    tier: itemConfig.tier,
+                    rank: itemConfig.rank,
+                }),
+            )
+            .filter((item): item is EquipmentItemInstance => Boolean(item));
 
         talentRanksByHeroId[hero.id] = talentRanks;
         talentPointsByHeroId[hero.id] = 0;
@@ -434,7 +471,7 @@ export const getCombatIdentityDistribution = (
 
 export const estimateEncounterWinRate = (
     partyClasses: HeroClass[],
-    level: number,
+    levels: number | number[],
     floor: number,
     attempts = 12,
     buildConfigs?: SnapshotHeroBuildConfig[],
@@ -442,7 +479,7 @@ export const estimateEncounterWinRate = (
     let wins = 0;
 
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
-        const party = partyClasses.map((heroClass, index) => createLeveledHero(heroClass, level, `hero_${index + 1}`));
+        const party = createSnapshotParty(partyClasses, levels);
         const buildProgression = createBuildProgression(party, buildConfigs);
         const outcome = runEncounter(party.map((hero) => cloneEntity(hero)), floor, attempt, buildProgression);
 
@@ -456,7 +493,7 @@ export const estimateEncounterWinRate = (
 
 export const estimateCheckpointRunWinRate = (
     partyClasses: HeroClass[],
-    level: number,
+    levels: number | number[],
     startFloor: number,
     endFloor: number,
     attempts = 12,
@@ -465,7 +502,7 @@ export const estimateCheckpointRunWinRate = (
     let wins = 0;
 
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
-        const party = partyClasses.map((heroClass, index) => createLeveledHero(heroClass, level, `hero_${index + 1}`));
+        const party = createSnapshotParty(partyClasses, levels);
         const buildProgression = createBuildProgression(party, buildConfigs);
         const outcome = runCheckpointSequence(
             party.map((hero) => cloneEntity(hero)),
@@ -490,25 +527,24 @@ export const createRepresentativeMilestoneWinRates = (attempts = 12): MilestoneW
         Archer: estimateEncounterWinRate(["Archer"], 1, 3, attempts),
     },
     floor8Duo: {
-        warriorClericLevel4: estimateEncounterWinRate(["Warrior", "Cleric"], 4, 8, attempts),
-        clericArcherLevel4: estimateEncounterWinRate(["Cleric", "Archer"], 4, 8, attempts),
+        warriorCleric: estimateEncounterWinRate(["Warrior", "Cleric"], [4, 4], 8, attempts),
+        clericArcher: estimateEncounterWinRate(["Cleric", "Archer"], [4, 4], 8, attempts),
     },
     floor10Boss: {
-        soloWarriorLevel5: estimateEncounterWinRate(["Warrior"], 5, 10, attempts),
-        soloClericLevel5: estimateEncounterWinRate(["Cleric"], 5, 10, attempts),
-        soloArcherLevel5: estimateEncounterWinRate(["Archer"], 5, 10, attempts),
-        duoWarriorClericLevel5: estimateEncounterWinRate(["Warrior", "Cleric"], 5, 10, attempts),
-        duoClericArcherLevel5: estimateEncounterWinRate(["Cleric", "Archer"], 5, 10, attempts),
+        soloWarrior: estimateEncounterWinRate(["Warrior"], 5, 10, attempts),
+        soloCleric: estimateEncounterWinRate(["Cleric"], 5, 10, attempts),
+        soloArcher: estimateEncounterWinRate(["Archer"], 5, 10, attempts),
+        duoWarriorCleric: estimateEncounterWinRate(["Warrior", "Cleric"], [5, 5], 10, attempts),
+        duoClericArcher: estimateEncounterWinRate(["Cleric", "Archer"], [5, 5], 10, attempts),
     },
-    floor18Slot4: {
-        trioWarriorClericArcherLevel10: estimateEncounterWinRate(["Warrior", "Cleric", "Archer"], 10, 18, attempts),
+    floor18Gate: {
+        warriorClericArcher: estimateEncounterWinRate(["Warrior", "Cleric", "Archer"], [13, 13, 12], 18, attempts),
     },
     floor20Boss: {
-        trioWarriorClericArcherLevel11: estimateEncounterWinRate(["Warrior", "Cleric", "Archer"], 11, 20, attempts),
-        trioWarriorClericArcherLevel12: estimateEncounterWinRate(["Warrior", "Cleric", "Archer"], 12, 20, attempts),
+        warriorClericArcher: estimateEncounterWinRate(["Warrior", "Cleric", "Archer"], [13, 13, 13], 20, attempts),
     },
-    floor28Slot5: {
-        quadWarriorClericClericArcherLevel13: estimateEncounterWinRate(["Warrior", "Cleric", "Cleric", "Archer"], 13, 28, attempts),
+    floor28Gate: {
+        warriorClericClericArcher: estimateEncounterWinRate(["Warrior", "Cleric", "Cleric", "Archer"], [18, 18, 17, 16], 28, attempts),
     },
 });
 
@@ -516,17 +552,17 @@ const createBuildAwareScenarioWinRates = (
     scenario: BuildAwareMilestoneScenario,
     attempts: number,
 ): BuildAwareMilestoneWinRates => ({
-    baseline: estimateEncounterWinRate(scenario.partyClasses, scenario.level, scenario.floor, attempts),
+    baseline: estimateEncounterWinRate(scenario.partyClasses, scenario.partyLevels, scenario.floor, attempts),
     expectedBuild: estimateEncounterWinRate(
         scenario.partyClasses,
-        scenario.level,
+        scenario.partyLevels,
         scenario.floor,
         attempts,
         scenario.expectedBuilds,
     ),
     curatedBuild: estimateEncounterWinRate(
         scenario.partyClasses,
-        scenario.level,
+        scenario.partyLevels,
         scenario.floor,
         attempts,
         scenario.curatedBuilds,
@@ -539,14 +575,14 @@ const createRecoveryAwareScenarioWinRates = (
 ): BuildAwareMilestoneWinRates => ({
     baseline: estimateCheckpointRunWinRate(
         scenario.partyClasses,
-        scenario.level,
+        scenario.partyLevels,
         scenario.startFloor,
         scenario.endFloor,
         attempts,
     ),
     expectedBuild: estimateCheckpointRunWinRate(
         scenario.partyClasses,
-        scenario.level,
+        scenario.partyLevels,
         scenario.startFloor,
         scenario.endFloor,
         attempts,
@@ -554,7 +590,7 @@ const createRecoveryAwareScenarioWinRates = (
     ),
     curatedBuild: estimateCheckpointRunWinRate(
         scenario.partyClasses,
-        scenario.level,
+        scenario.partyLevels,
         scenario.startFloor,
         scenario.endFloor,
         attempts,
@@ -565,241 +601,372 @@ const createRecoveryAwareScenarioWinRates = (
 const BUILD_AWARE_SCENARIOS = {
     floor8WarriorCleric: {
         partyClasses: ["Warrior", "Cleric"],
-        level: 4,
+        partyLevels: [4, 4],
         floor: 8,
         expectedBuilds: [
             {
-                talentIds: ["warrior-unyielding"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate"],
+                talentRanks: { "warrior-unyielding": 2 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 2, 1),
+                    gear("bastion-plate", 2, 1),
+                ],
             },
             {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments"],
+                talentRanks: { "cleric-shepherd": 2 },
+                equippedItems: [
+                    gear("sunlit-censer", 2, 1),
+                    gear("pilgrim-vestments", 2, 1),
+                ],
             },
         ],
         curatedBuilds: [
             {
-                talentIds: ["warrior-unyielding", "warrior-rampage"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate", "whetstone-token", "timeworn-hourglass"],
+                talentRanks: { "warrior-unyielding": 2 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 2, 2),
+                    gear("bastion-plate", 2, 2),
+                    gear("whetstone-token", 2, 2),
+                    gear("timeworn-hourglass", 2, 2),
+                ],
             },
             {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments", "ember-charm", "iron-prayer-bead"],
+                talentRanks: { "cleric-shepherd": 2 },
+                equippedItems: [
+                    gear("sunlit-censer", 2, 2),
+                    gear("pilgrim-vestments", 2, 2),
+                    gear("ember-charm", 2, 2),
+                    gear("iron-prayer-bead", 2, 2),
+                ],
             },
         ],
     },
     floor8ClericArcher: {
         partyClasses: ["Cleric", "Archer"],
-        level: 4,
+        partyLevels: [4, 4],
         floor: 8,
         expectedBuilds: [
             {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments"],
+                talentRanks: { "cleric-shepherd": 2 },
+                equippedItems: [
+                    gear("sunlit-censer", 2, 1),
+                    gear("pilgrim-vestments", 2, 1),
+                ],
             },
             {
-                talentIds: ["archer-deadeye"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers"],
+                talentRanks: { "archer-deadeye": 2 },
+                equippedItems: [
+                    gear("hawkstring-bow", 2, 1),
+                    gear("shadowhide-leathers", 2, 1),
+                ],
             },
         ],
         curatedBuilds: [
             {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments", "ember-charm", "iron-prayer-bead"],
+                talentRanks: { "cleric-shepherd": 2 },
+                equippedItems: [
+                    gear("sunlit-censer", 2, 2),
+                    gear("pilgrim-vestments", 2, 2),
+                    gear("ember-charm", 2, 2),
+                    gear("iron-prayer-bead", 2, 2),
+                ],
             },
             {
-                talentIds: ["archer-deadeye", "archer-quickdraw"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers", "duelist-loop", "timeworn-hourglass"],
+                talentRanks: { "archer-deadeye": 2 },
+                equippedItems: [
+                    gear("hawkstring-bow", 2, 2),
+                    gear("shadowhide-leathers", 2, 2),
+                    gear("duelist-loop", 2, 2),
+                    gear("timeworn-hourglass", 2, 2),
+                ],
             },
         ],
     },
     floor10WarriorCleric: {
         partyClasses: ["Warrior", "Cleric"],
-        level: 5,
+        partyLevels: [5, 5],
         floor: 10,
         expectedBuilds: [
             {
-                talentIds: ["warrior-unyielding"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate"],
+                talentRanks: { "warrior-unyielding": 2 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 3, 2),
+                    gear("bastion-plate", 3, 2),
+                ],
             },
             {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments"],
+                talentRanks: { "cleric-shepherd": 2 },
+                equippedItems: [
+                    gear("sunlit-censer", 3, 2),
+                    gear("pilgrim-vestments", 3, 2),
+                ],
             },
         ],
         curatedBuilds: [
             {
-                talentIds: ["warrior-unyielding", "warrior-rampage"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate", "whetstone-token", "timeworn-hourglass"],
+                talentRanks: { "warrior-unyielding": 2 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 3, 3),
+                    gear("bastion-plate", 3, 3),
+                    gear("whetstone-token", 3, 3),
+                    gear("timeworn-hourglass", 3, 3),
+                ],
             },
             {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments", "ember-charm", "iron-prayer-bead"],
+                talentRanks: { "cleric-shepherd": 2 },
+                equippedItems: [
+                    gear("sunlit-censer", 3, 3),
+                    gear("pilgrim-vestments", 3, 3),
+                    gear("ember-charm", 3, 3),
+                    gear("iron-prayer-bead", 3, 3),
+                ],
             },
         ],
     },
     floor10ClericArcher: {
         partyClasses: ["Cleric", "Archer"],
-        level: 5,
+        partyLevels: [5, 5],
         floor: 10,
         expectedBuilds: [
             {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments"],
+                talentRanks: { "cleric-shepherd": 2 },
+                equippedItems: [
+                    gear("sunlit-censer", 3, 2),
+                    gear("pilgrim-vestments", 3, 2),
+                ],
             },
             {
-                talentIds: ["archer-deadeye"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers"],
+                talentRanks: { "archer-deadeye": 2 },
+                equippedItems: [
+                    gear("hawkstring-bow", 3, 2),
+                    gear("shadowhide-leathers", 3, 2),
+                ],
             },
         ],
         curatedBuilds: [
             {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments", "ember-charm", "iron-prayer-bead"],
+                talentRanks: { "cleric-shepherd": 2 },
+                equippedItems: [
+                    gear("sunlit-censer", 3, 3),
+                    gear("pilgrim-vestments", 3, 3),
+                    gear("ember-charm", 3, 3),
+                    gear("iron-prayer-bead", 3, 3),
+                ],
             },
             {
-                talentIds: ["archer-deadeye", "archer-quickdraw"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers", "duelist-loop", "timeworn-hourglass"],
+                talentRanks: { "archer-deadeye": 2 },
+                equippedItems: [
+                    gear("hawkstring-bow", 3, 3),
+                    gear("shadowhide-leathers", 3, 3),
+                    gear("duelist-loop", 3, 3),
+                    gear("timeworn-hourglass", 3, 3),
+                ],
             },
         ],
     },
     floor18WarriorClericArcher: {
         partyClasses: ["Warrior", "Cleric", "Archer"],
-        level: 10,
+        partyLevels: [13, 13, 12],
         floor: 18,
         expectedBuilds: [
             {
-                talentIds: ["warrior-unyielding"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate"],
+                talentRanks: { "warrior-unyielding": 3, "warrior-rampage": 3 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 4, 3),
+                    gear("bastion-plate", 4, 3),
+                    gear("whetstone-token", 4, 3),
+                    gear("timeworn-hourglass", 4, 3),
+                ],
             },
             {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments"],
+                talentRanks: { "cleric-sunfire": 3, "cleric-shepherd": 3 },
+                equippedItems: [
+                    gear("sunlit-censer", 4, 3),
+                    gear("pilgrim-vestments", 4, 3),
+                    gear("ember-charm", 4, 3),
+                    gear("iron-prayer-bead", 4, 3),
+                ],
             },
             {
-                talentIds: ["archer-deadeye"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers"],
+                talentRanks: { "archer-deadeye": 3, "archer-quickdraw": 3 },
+                equippedItems: [
+                    gear("hawkstring-bow", 4, 3),
+                    gear("shadowhide-leathers", 4, 3),
+                    gear("duelist-loop", 4, 3),
+                    gear("timeworn-hourglass", 4, 3),
+                ],
             },
         ],
         curatedBuilds: [
             {
-                talentIds: ["warrior-unyielding", "warrior-rampage"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate", "whetstone-token", "ward-icon"],
+                talentRanks: { "warrior-unyielding": 3, "warrior-rampage": 3 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 4, 4),
+                    gear("bastion-plate", 4, 4),
+                    gear("whetstone-token", 4, 4),
+                    gear("ward-icon", 4, 4),
+                ],
             },
             {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments", "ember-charm", "iron-prayer-bead"],
+                talentRanks: { "cleric-sunfire": 3, "cleric-shepherd": 3 },
+                equippedItems: [
+                    gear("sunlit-censer", 4, 4),
+                    gear("pilgrim-vestments", 4, 4),
+                    gear("ember-charm", 4, 4),
+                    gear("iron-prayer-bead", 4, 4),
+                ],
             },
             {
-                talentIds: ["archer-deadeye", "archer-quickdraw"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers", "duelist-loop", "timeworn-hourglass"],
+                talentRanks: { "archer-deadeye": 3, "archer-quickdraw": 3 },
+                equippedItems: [
+                    gear("hawkstring-bow", 4, 4),
+                    gear("shadowhide-leathers", 4, 4),
+                    gear("duelist-loop", 4, 4),
+                    gear("timeworn-hourglass", 4, 4),
+                ],
             },
         ],
     },
-    floor20WarriorClericArcherLevel11: {
+    floor20WarriorClericArcher: {
         partyClasses: ["Warrior", "Cleric", "Archer"],
-        level: 11,
+        partyLevels: [13, 13, 13],
         floor: 20,
         expectedBuilds: [
             {
-                talentIds: ["warrior-unyielding"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate"],
+                talentRanks: { "warrior-unyielding": 3, "warrior-rampage": 3 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 4, 3),
+                    gear("bastion-plate", 4, 3),
+                    gear("whetstone-token", 4, 3),
+                    gear("timeworn-hourglass", 4, 3),
+                ],
             },
             {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments"],
+                talentRanks: { "cleric-sunfire": 3, "cleric-shepherd": 3 },
+                equippedItems: [
+                    gear("sunlit-censer", 4, 3),
+                    gear("pilgrim-vestments", 4, 3),
+                    gear("ember-charm", 4, 3),
+                    gear("iron-prayer-bead", 4, 3),
+                ],
             },
             {
-                talentIds: ["archer-deadeye"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers"],
+                talentRanks: { "archer-deadeye": 3, "archer-quickdraw": 3 },
+                equippedItems: [
+                    gear("hawkstring-bow", 4, 3),
+                    gear("shadowhide-leathers", 4, 3),
+                    gear("duelist-loop", 4, 3),
+                    gear("timeworn-hourglass", 4, 3),
+                ],
             },
         ],
         curatedBuilds: [
             {
-                talentIds: ["warrior-unyielding", "warrior-rampage"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate", "whetstone-token", "ward-icon"],
+                talentRanks: { "warrior-unyielding": 3, "warrior-rampage": 3 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 4, 4),
+                    gear("bastion-plate", 4, 4),
+                    gear("whetstone-token", 4, 4),
+                    gear("ward-icon", 4, 4),
+                ],
             },
             {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments", "ember-charm", "iron-prayer-bead"],
+                talentRanks: { "cleric-sunfire": 3, "cleric-shepherd": 3 },
+                equippedItems: [
+                    gear("sunlit-censer", 4, 4),
+                    gear("pilgrim-vestments", 4, 4),
+                    gear("ember-charm", 4, 4),
+                    gear("iron-prayer-bead", 4, 4),
+                ],
             },
             {
-                talentIds: ["archer-deadeye", "archer-quickdraw"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers", "duelist-loop", "timeworn-hourglass"],
-            },
-        ],
-    },
-    floor20WarriorClericArcherLevel12: {
-        partyClasses: ["Warrior", "Cleric", "Archer"],
-        level: 12,
-        floor: 20,
-        expectedBuilds: [
-            {
-                talentIds: ["warrior-unyielding"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate"],
-            },
-            {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments"],
-            },
-            {
-                talentIds: ["archer-deadeye"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers"],
-            },
-        ],
-        curatedBuilds: [
-            {
-                talentIds: ["warrior-unyielding", "warrior-rampage"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate", "whetstone-token", "ward-icon"],
-            },
-            {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments", "ember-charm", "iron-prayer-bead"],
-            },
-            {
-                talentIds: ["archer-deadeye", "archer-quickdraw"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers", "duelist-loop", "timeworn-hourglass"],
+                talentRanks: { "archer-deadeye": 3, "archer-quickdraw": 3 },
+                equippedItems: [
+                    gear("hawkstring-bow", 4, 4),
+                    gear("shadowhide-leathers", 4, 4),
+                    gear("duelist-loop", 4, 4),
+                    gear("timeworn-hourglass", 4, 4),
+                ],
             },
         ],
     },
     floor28WarriorClericClericArcher: {
         partyClasses: ["Warrior", "Cleric", "Cleric", "Archer"],
-        level: 13,
+        partyLevels: [18, 18, 17, 16],
         floor: 28,
         expectedBuilds: [
             {
-                talentIds: ["warrior-unyielding"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate"],
+                talentRanks: { "warrior-unyielding": 3, "warrior-rampage": 3 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 5, 4),
+                    gear("bastion-plate", 5, 4),
+                    gear("whetstone-token", 5, 4),
+                    gear("ward-icon", 5, 4),
+                ],
             },
             {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments"],
+                talentRanks: { "cleric-sunfire": 3, "cleric-shepherd": 3 },
+                equippedItems: [
+                    gear("sunlit-censer", 5, 4),
+                    gear("pilgrim-vestments", 5, 4),
+                    gear("ember-charm", 5, 4),
+                    gear("iron-prayer-bead", 5, 4),
+                ],
             },
             {
-                talentIds: ["cleric-shepherd"],
-                equippedItemIds: ["ward-icon", "iron-prayer-bead"],
+                talentRanks: { "cleric-sunfire": 3, "cleric-shepherd": 3 },
+                equippedItems: [
+                    gear("sunlit-censer", 5, 4),
+                    gear("pilgrim-vestments", 5, 4),
+                    gear("ember-charm", 5, 4),
+                    gear("iron-prayer-bead", 5, 4),
+                ],
             },
             {
-                talentIds: ["archer-deadeye"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers"],
+                talentRanks: { "archer-deadeye": 3, "archer-quickdraw": 3 },
+                equippedItems: [
+                    gear("hawkstring-bow", 5, 4),
+                    gear("shadowhide-leathers", 5, 4),
+                    gear("duelist-loop", 5, 4),
+                    gear("timeworn-hourglass", 5, 4),
+                ],
             },
         ],
         curatedBuilds: [
             {
-                talentIds: ["warrior-unyielding", "warrior-rampage"],
-                equippedItemIds: ["greatblade-of-embers", "bastion-plate", "whetstone-token"],
+                talentRanks: { "warrior-unyielding": 3, "warrior-rampage": 3 },
+                equippedItems: [
+                    gear("greatblade-of-embers", 5, 5),
+                    gear("bastion-plate", 5, 5),
+                    gear("whetstone-token", 5, 5),
+                    gear("ward-icon", 5, 5),
+                ],
             },
             {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["sunlit-censer", "pilgrim-vestments", "ember-charm"],
+                talentRanks: { "cleric-sunfire": 3, "cleric-shepherd": 3 },
+                equippedItems: [
+                    gear("sunlit-censer", 5, 5),
+                    gear("pilgrim-vestments", 5, 5),
+                    gear("ember-charm", 5, 5),
+                    gear("iron-prayer-bead", 5, 5),
+                ],
             },
             {
-                talentIds: ["cleric-sunfire", "cleric-shepherd"],
-                equippedItemIds: ["iron-prayer-bead", "ward-icon"],
+                talentRanks: { "cleric-sunfire": 3, "cleric-shepherd": 3 },
+                equippedItems: [
+                    gear("sunlit-censer", 5, 5),
+                    gear("pilgrim-vestments", 5, 5),
+                    gear("ember-charm", 5, 5),
+                    gear("iron-prayer-bead", 5, 5),
+                ],
             },
             {
-                talentIds: ["archer-deadeye", "archer-quickdraw"],
-                equippedItemIds: ["hawkstring-bow", "shadowhide-leathers", "duelist-loop", "timeworn-hourglass"],
+                talentRanks: { "archer-deadeye": 3, "archer-quickdraw": 3 },
+                equippedItems: [
+                    gear("hawkstring-bow", 5, 5),
+                    gear("shadowhide-leathers", 5, 5),
+                    gear("duelist-loop", 5, 5),
+                    gear("timeworn-hourglass", 5, 5),
+                ],
             },
         ],
     },
@@ -831,13 +998,8 @@ const RECOVERY_AWARE_SCENARIOS = {
         startFloor: 16,
         endFloor: 18,
     },
-    floor20WarriorClericArcherLevel11: {
-        ...BUILD_AWARE_SCENARIOS.floor20WarriorClericArcherLevel11,
-        startFloor: 19,
-        endFloor: 20,
-    },
-    floor20WarriorClericArcherLevel12: {
-        ...BUILD_AWARE_SCENARIOS.floor20WarriorClericArcherLevel12,
+    floor20WarriorClericArcher: {
+        ...BUILD_AWARE_SCENARIOS.floor20WarriorClericArcher,
         startFloor: 19,
         endFloor: 20,
     },
@@ -850,52 +1012,41 @@ const RECOVERY_AWARE_SCENARIOS = {
 
 export const createBuildAwareMilestoneWinRates = (attempts = 12): BuildAwareMilestoneWinRateSnapshot => ({
     floor8Duo: {
-        warriorClericLevel4: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor8WarriorCleric, attempts),
-        clericArcherLevel4: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor8ClericArcher, attempts),
+        warriorCleric: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor8WarriorCleric, attempts),
+        clericArcher: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor8ClericArcher, attempts),
     },
     floor10Boss: {
-        duoWarriorClericLevel5: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor10WarriorCleric, attempts),
-        duoClericArcherLevel5: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor10ClericArcher, attempts),
+        duoWarriorCleric: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor10WarriorCleric, attempts),
+        duoClericArcher: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor10ClericArcher, attempts),
     },
-    floor18Slot4: {
-        trioWarriorClericArcherLevel10: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor18WarriorClericArcher, attempts),
+    floor18Gate: {
+        warriorClericArcher: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor18WarriorClericArcher, attempts),
     },
     floor20Boss: {
-        trioWarriorClericArcherLevel11: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor20WarriorClericArcherLevel11, attempts),
-        trioWarriorClericArcherLevel12: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor20WarriorClericArcherLevel12, attempts),
+        warriorClericArcher: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor20WarriorClericArcher, attempts),
     },
-    floor28Slot5: {
-        quadWarriorClericClericArcherLevel13: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor28WarriorClericClericArcher, attempts),
+    floor28Gate: {
+        warriorClericClericArcher: createBuildAwareScenarioWinRates(BUILD_AWARE_SCENARIOS.floor28WarriorClericClericArcher, attempts),
     },
 });
 
 export const createRecoveryAwareMilestoneWinRates = (attempts = 12): RecoveryAwareMilestoneWinRateSnapshot => ({
     floor8Duo: {
-        warriorClericLevel4: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor8WarriorCleric, attempts),
-        clericArcherLevel4: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor8ClericArcher, attempts),
+        warriorCleric: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor8WarriorCleric, attempts),
+        clericArcher: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor8ClericArcher, attempts),
     },
     floor10Boss: {
-        duoWarriorClericLevel5: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor10WarriorCleric, attempts),
-        duoClericArcherLevel5: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor10ClericArcher, attempts),
+        duoWarriorCleric: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor10WarriorCleric, attempts),
+        duoClericArcher: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor10ClericArcher, attempts),
     },
-    floor18Slot4: {
-        trioWarriorClericArcherLevel10: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor18WarriorClericArcher, attempts),
+    floor18Gate: {
+        warriorClericArcher: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor18WarriorClericArcher, attempts),
     },
     floor20Boss: {
-        trioWarriorClericArcherLevel11: createRecoveryAwareScenarioWinRates(
-            RECOVERY_AWARE_SCENARIOS.floor20WarriorClericArcherLevel11,
-            attempts,
-        ),
-        trioWarriorClericArcherLevel12: createRecoveryAwareScenarioWinRates(
-            RECOVERY_AWARE_SCENARIOS.floor20WarriorClericArcherLevel12,
-            attempts,
-        ),
+        warriorClericArcher: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor20WarriorClericArcher, attempts),
     },
-    floor28Slot5: {
-        quadWarriorClericClericArcherLevel13: createRecoveryAwareScenarioWinRates(
-            RECOVERY_AWARE_SCENARIOS.floor28WarriorClericClericArcher,
-            attempts,
-        ),
+    floor28Gate: {
+        warriorClericClericArcher: createRecoveryAwareScenarioWinRates(RECOVERY_AWARE_SCENARIOS.floor28WarriorClericClericArcher, attempts),
     },
 });
 


### PR DESCRIPTION
## Summary
- refresh the balance snapshot harness to use current first-region party levels instead of the old late-floor level assumptions
- model ranked talents and tier/rank-aware equipment in the build-aware scenarios
- regenerate the balance snapshot tests and update the balance ADRs to match the live results

## Validation
- npm run lint
- npm run build
- npm run test

## Notes
- Floor 18 and Floor 20 are no longer treated as the old stale low-level wall cases
- Floor 28 remains the main structural late-region gate in the refreshed snapshot baseline

Related to #93