### PR TITLE
🧹 [code health] Remove unused export getEquipmentItem

### DIFF
--- a/src/game/heroBuilds.ts
+++ b/src/game/heroBuilds.ts
@@ -492,8 +492,6 @@ export const getTotalTalentRankCapacity = (heroClass: HeroClass) =>
 
 export const getEquipmentDefinition = (definitionId: string) => EQUIPMENT_LOOKUP.get(definitionId) ?? null;
 
-export const getEquipmentItem = getEquipmentDefinition;
-
 export const getEquipmentSellValue = (definition: EquipmentItemDefinition, tier: number, rank: number) =>
     definition.sellValueBase + ((tier - 1) * definition.sellValuePerTier) + ((rank - 1) * definition.sellValuePerRank);
 


### PR DESCRIPTION
Removed the unused export `getEquipmentItem` from `src/game/heroBuilds.ts`. 
This export was a redundant alias for `getEquipmentDefinition` and was not referenced anywhere else in the codebase.

🎯 What: Removed dead code in `src/game/heroBuilds.ts`.
💡 Why: Improves maintainability by removing redundant exports and reducing API surface area.
✅ Verification: Confirmed with `grep -r` that `getEquipmentItem` is not used elsewhere. Code review confirmed the change is safe.
✨ Result: Cleaner codebase with no unused exports for this module.

---
*PR created automatically by Jules for task [6761901561665958811](https://jules.google.com/task/6761901561665958811) started by @deadronos*