### PR TITLE
🧪 [testing improvement] add tests for getInsightXpMultiplier

### DIFF
--- a/src/game/progressionMath.test.ts
+++ b/src/game/progressionMath.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getInsightXpMultiplier, INSIGHT_XP_BONUS_PER_LEVEL } from "./progressionMath";
+
+describe("progressionMath", () => {
+  describe("getInsightXpMultiplier", () => {
+    it("returns 1 when insight level is 0", () => {
+      expect(getInsightXpMultiplier(0)).toBe(1);
+    });
+
+    it("returns the correct multiplier for insight level 1", () => {
+      expect(getInsightXpMultiplier(1)).toBe(1 + INSIGHT_XP_BONUS_PER_LEVEL);
+    });
+
+    it("returns the correct multiplier for a higher insight level (e.g., 10)", () => {
+      expect(getInsightXpMultiplier(10)).toBe(1 + (10 * INSIGHT_XP_BONUS_PER_LEVEL));
+    });
+
+    it("handles negative insight levels correctly", () => {
+      expect(getInsightXpMultiplier(-1)).toBe(1 - INSIGHT_XP_BONUS_PER_LEVEL);
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds unit tests for the `getInsightXpMultiplier` function in `src/game/progressionMath.ts`.

📊 **Coverage:** What scenarios are now tested
- **Base Case:** Insight level 0 returns a multiplier of 1.
- **Standard Case:** Insight level 1 returns 1 + `INSIGHT_XP_BONUS_PER_LEVEL`.
- **Higher Level Case:** Insight level 10 returns 1 + (10 * `INSIGHT_XP_BONUS_PER_LEVEL`).
- **Edge Case:** Negative insight levels are handled correctly by the formula.

✨ **Result:** The improvement in test coverage
The `getInsightXpMultiplier` function, which is a key part of the game's progression math, is now covered by unit tests, ensuring that future changes to this formula or its constants won't introduce regressions.

---
*PR created automatically by Jules for task [4194373043571217285](https://jules.google.com/task/4194373043571217285) started by @deadronos*